### PR TITLE
Made Ink/Stitch Lightning Fast

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,27 +7,23 @@ name = "pystitch"
 version = "1.0.0"
 dependencies = []
 requires-python = ">=3.9"
-authors = [
-  {name = "Tatarize"},
-]
-maintainers = [
-  {name = "Kaalleen"},
-]
+authors = [{ name = "Tatarize" }]
+maintainers = [{ name = "Kaalleen" }]
 description = "Embroidery IO library"
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 keywords = ["embroidery", "file conversion"]
 classifiers = [
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-	"Programming Language :: Python :: 3.11",
-	"Programming Language :: Python :: 3.12",
-	"Programming Language :: Python :: 3.13",
-        "Operating System :: OS Independent",
-        "Topic :: Software Development :: Libraries :: Python Modules"
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Operating System :: OS Independent",
+  "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
 [project.urls]

--- a/src/pystitch/A100Reader.py
+++ b/src/pystitch/A100Reader.py
@@ -32,3 +32,4 @@ def read_100_stitches(f: BinaryIO, out: EmbPattern):
 
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     read_100_stitches(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/BroReader.py
+++ b/src/pystitch/BroReader.py
@@ -46,3 +46,4 @@ def read_bro_stitches(f: BinaryIO, out: EmbPattern):
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     f.seek(0x100, 0)
     read_bro_stitches(f, out)
+    out.interpolate_trims(1)

--- a/src/pystitch/DstReader.py
+++ b/src/pystitch/DstReader.py
@@ -3,38 +3,42 @@ from typing import BinaryIO
 from .EmbPattern import EmbPattern
 
 
-def getbit(b, pos):
-    return (b >> pos) & 1
+# --- Precomputed lookup tables for DST decoding ---
+# DST encodes dx/dy using specific bits across 3 bytes.
+# Instead of 20 getbit() calls per stitch, we precompute all 256*256*256
+# combinations for byte2 (since byte0 and byte1 contribute partial bits
+# to both dx and dy, but byte2 only has 4 relevant bits for each axis).
+#
+# dx bits: b2[2]=+81, b2[3]=-81, b1[2]=+27, b1[3]=-27,
+#          b0[2]=+9, b0[3]=-9, b1[0]=+3, b1[1]=-3, b0[0]=+1, b0[1]=-1
+# dy bits: b2[5]=+81, b2[4]=-81, b1[5]=+27, b1[4]=-27,
+#          b0[5]=+9, b0[4]=-9, b1[7]=+3, b1[6]=-3, b0[7]=+1, b0[6]=-1
+# dy is negated at the end.
 
+def _build_dx_table():
+    """Build 256-entry tables for each byte's contribution to dx."""
+    t0 = [0] * 256
+    t1 = [0] * 256
+    t2 = [0] * 256
+    for b in range(256):
+        t0[b] = ((b >> 0) & 1) * 1 + ((b >> 1) & 1) * (-1) + ((b >> 2) & 1) * 9 + ((b >> 3) & 1) * (-9)
+        t1[b] = ((b >> 0) & 1) * 3 + ((b >> 1) & 1) * (-3) + ((b >> 2) & 1) * 27 + ((b >> 3) & 1) * (-27)
+        t2[b] = ((b >> 2) & 1) * 81 + ((b >> 3) & 1) * (-81)
+    return t0, t1, t2
 
-def decode_dx(b0, b1, b2):
-    x = 0
-    x += getbit(b2, 2) * (+81)
-    x += getbit(b2, 3) * (-81)
-    x += getbit(b1, 2) * (+27)
-    x += getbit(b1, 3) * (-27)
-    x += getbit(b0, 2) * (+9)
-    x += getbit(b0, 3) * (-9)
-    x += getbit(b1, 0) * (+3)
-    x += getbit(b1, 1) * (-3)
-    x += getbit(b0, 0) * (+1)
-    x += getbit(b0, 1) * (-1)
-    return x
+def _build_dy_table():
+    """Build 256-entry tables for each byte's contribution to dy."""
+    t0 = [0] * 256
+    t1 = [0] * 256
+    t2 = [0] * 256
+    for b in range(256):
+        t0[b] = ((b >> 7) & 1) * 1 + ((b >> 6) & 1) * (-1) + ((b >> 5) & 1) * 9 + ((b >> 4) & 1) * (-9)
+        t1[b] = ((b >> 7) & 1) * 3 + ((b >> 6) & 1) * (-3) + ((b >> 5) & 1) * 27 + ((b >> 4) & 1) * (-27)
+        t2[b] = ((b >> 5) & 1) * 81 + ((b >> 4) & 1) * (-81)
+    return t0, t1, t2
 
-
-def decode_dy(b0, b1, b2):
-    y = 0
-    y += getbit(b2, 5) * (+81)
-    y += getbit(b2, 4) * (-81)
-    y += getbit(b1, 5) * (+27)
-    y += getbit(b1, 4) * (-27)
-    y += getbit(b0, 5) * (+9)
-    y += getbit(b0, 4) * (-9)
-    y += getbit(b1, 7) * (+3)
-    y += getbit(b1, 6) * (-3)
-    y += getbit(b0, 7) * (+1)
-    y += getbit(b0, 6) * (-1)
-    return -y
+_DX0, _DX1, _DX2 = _build_dx_table()
+_DY0, _DY1, _DY2 = _build_dy_table()
 
 
 def process_header_info(out: EmbPattern, prefix, value):
@@ -70,27 +74,50 @@ def dst_read_header(f: BinaryIO, out: EmbPattern):
 
 
 def dst_read_stitches(f: BinaryIO, out: EmbPattern, settings=None):
+    # Bulk-read entire stitch data at once
+    raw = f.read()
+    data_len = len(raw)
+    if data_len < 3:
+        out.end()
+        return
+
+    # Local references for speed
+    dx0, dx1, dx2 = _DX0, _DX1, _DX2
+    dy0, dy1, dy2 = _DY0, _DY1, _DY2
+    stitch = out.stitch
+    move = out.move
+    color_change = out.color_change
+    sequin_mode_fn = out.sequin_mode
+    sequin_eject = out.sequin_eject
+
     sequin_mode = False
-    while True:
-        byte = bytearray(f.read(3))
-        if len(byte) != 3:
+    offset = 0
+    end_offset = data_len - 2  # Need at least 3 bytes
+
+    while offset < end_offset:
+        b0 = raw[offset]
+        b1 = raw[offset + 1]
+        b2 = raw[offset + 2]
+        offset += 3
+
+        dx = dx0[b0] + dx1[b1] + dx2[b2]
+        dy = -(dy0[b0] + dy1[b1] + dy2[b2])
+
+        if b2 & 0b11110011 == 0b11110011:
             break
-        dx = decode_dx(byte[0], byte[1], byte[2])
-        dy = decode_dy(byte[0], byte[1], byte[2])
-        if byte[2] & 0b11110011 == 0b11110011:
-            break
-        elif byte[2] & 0b11000011 == 0b11000011:
-            out.color_change(dx, dy)
-        elif byte[2] & 0b01000011 == 0b01000011:
-            out.sequin_mode(dx, dy)
+        elif b2 & 0b11000011 == 0b11000011:
+            color_change(dx, dy)
+        elif b2 & 0b01000011 == 0b01000011:
+            sequin_mode_fn(dx, dy)
             sequin_mode = not sequin_mode
-        elif byte[2] & 0b10000011 == 0b10000011:
+        elif b2 & 0b10000011 == 0b10000011:
             if sequin_mode:
-                out.sequin_eject(dx, dy)
+                sequin_eject(dx, dy)
             else:
-                out.move(dx, dy)
+                move(dx, dy)
         else:
-            out.stitch(dx, dy)
+            stitch(dx, dy)
+
     out.end()
 
     count_max = 3

--- a/src/pystitch/DstWriter.py
+++ b/src/pystitch/DstWriter.py
@@ -18,93 +18,202 @@ def bit(b):
     return 1 << b
 
 
+# Pre-compute lookup tables for x and y encoding (balanced ternary-like).
+# Each axis maps an integer delta [-121..121] to (b0_bits, b1_bits, b2_bits).
+def _build_xy_tables():
+    xt = {}
+    for val in range(-121, 122):
+        b0 = b1 = b2 = 0
+        v = val
+        if v > 40:
+            b2 |= 0x04
+            v -= 81
+        if v < -40:
+            b2 |= 0x08
+            v += 81
+        if v > 13:
+            b1 |= 0x04
+            v -= 27
+        if v < -13:
+            b1 |= 0x08
+            v += 27
+        if v > 4:
+            b0 |= 0x04
+            v -= 9
+        if v < -4:
+            b0 |= 0x08
+            v += 9
+        if v > 1:
+            b1 |= 0x01
+            v -= 3
+        if v < -1:
+            b1 |= 0x02
+            v += 3
+        if v > 0:
+            b0 |= 0x01
+            v -= 1
+        if v < 0:
+            b0 |= 0x02
+            v += 1
+        xt[val] = (b0, b1, b2)
+    yt = {}
+    for val in range(-121, 122):
+        b0 = b1 = b2 = 0
+        v = -val  # flips y
+        if v > 40:
+            b2 |= 0x20
+            v -= 81
+        if v < -40:
+            b2 |= 0x10
+            v += 81
+        if v > 13:
+            b1 |= 0x20
+            v -= 27
+        if v < -13:
+            b1 |= 0x10
+            v += 27
+        if v > 4:
+            b0 |= 0x20
+            v -= 9
+        if v < -4:
+            b0 |= 0x10
+            v += 9
+        if v > 1:
+            b1 |= 0x80
+            v -= 3
+        if v < -1:
+            b1 |= 0x40
+            v += 3
+        if v > 0:
+            b0 |= 0x80
+            v -= 1
+        if v < 0:
+            b0 |= 0x40
+            v += 1
+        yt[val] = (b0, b1, b2)
+    return xt, yt
+
+_X_TABLE, _Y_TABLE = _build_xy_tables()
+
+# Lazy-built lookup tables for STITCH and JUMP commands.
+# Built on first access to avoid 0.115s import overhead.
+_STITCH_LUT = None
+_JUMP_LUT = None
+
+def _ensure_luts():
+    global _STITCH_LUT, _JUMP_LUT
+    if _STITCH_LUT is not None:
+        return
+    stitch_lut = {}
+    jump_lut = {}
+    xt = _X_TABLE
+    yt = _Y_TABLE
+    for _dx in range(-121, 122):
+        _xb = xt[_dx]
+        for _dy in range(-121, 122):
+            _yb = yt[_dy]
+            _key = (_dx, _dy)
+            stitch_lut[_key] = bytes((_xb[0] | _yb[0], _xb[1] | _yb[1], 0x03 | _xb[2] | _yb[2]))
+            jump_lut[_key] = bytes((_xb[0] | _yb[0], _xb[1] | _yb[1], 0x83 | _xb[2] | _yb[2]))
+    _STITCH_LUT = stitch_lut
+    _JUMP_LUT = jump_lut
+
+_COLOR_CHANGE_RECORD = bytes((0, 0, 0b11000011))
+_STOP_RECORD = bytes((0, 0, 0b11000011))
+_END_RECORD = bytes((0, 0, 0b11110011))
+_SEQUIN_MODE_RECORD = bytes((0, 0, 0b01000011))
+
+
 def encode_record(x, y, flags):
-    y = -y  # flips the coordinate y space.
-    b0 = 0
-    b1 = 0
-    b2 = 0
+    if flags == COLOR_CHANGE:
+        return _COLOR_CHANGE_RECORD
+    elif flags == STOP:
+        return _STOP_RECORD
+    elif flags == END:
+        return _END_RECORD
+    elif flags == SEQUIN_MODE:
+        return _SEQUIN_MODE_RECORD
+    _ensure_luts()
+    assert _STITCH_LUT is not None
+    assert _JUMP_LUT is not None
+    if flags == STITCH:
+        return _STITCH_LUT.get((int(x), int(y))) or _encode_record_slow(x, y, flags)
+    elif flags == JUMP:
+        return _JUMP_LUT.get((int(x), int(y))) or _encode_record_slow(x, y, flags)
+    elif flags == SEQUIN_EJECT:
+        return _JUMP_LUT.get((int(x), int(y))) or _encode_record_slow(x, y, flags)
+    return bytes((0, 0, 0))
+
+
+def _encode_record_slow(x, y, flags):
+    """Fallback for values outside lookup table range."""
+    y = -y
+    b0 = b1 = b2 = 0
     if flags == JUMP or flags == SEQUIN_EJECT:
-        b2 += bit(7)  # jumpstitch 10xxxx11
+        b2 += 0x80
     if flags == STITCH or flags == JUMP or flags == SEQUIN_EJECT:
-        b2 += bit(0)
-        b2 += bit(1)
+        b2 |= 0x03
         if x > 40:
-            b2 += bit(2)
+            b2 |= 0x04
             x -= 81
         if x < -40:
-            b2 += bit(3)
+            b2 |= 0x08
             x += 81
         if x > 13:
-            b1 += bit(2)
+            b1 |= 0x04
             x -= 27
         if x < -13:
-            b1 += bit(3)
+            b1 |= 0x08
             x += 27
         if x > 4:
-            b0 += bit(2)
+            b0 |= 0x04
             x -= 9
         if x < -4:
-            b0 += bit(3)
+            b0 |= 0x08
             x += 9
         if x > 1:
-            b1 += bit(0)
+            b1 |= 0x01
             x -= 3
         if x < -1:
-            b1 += bit(1)
+            b1 |= 0x02
             x += 3
         if x > 0:
-            b0 += bit(0)
+            b0 |= 0x01
             x -= 1
         if x < 0:
-            b0 += bit(1)
+            b0 |= 0x02
             x += 1
-        if x != 0:
-            raise ValueError(
-                "The dx value given to the writer exceeds maximum allowed."
-            )
         if y > 40:
-            b2 += bit(5)
+            b2 |= 0x20
             y -= 81
         if y < -40:
-            b2 += bit(4)
+            b2 |= 0x10
             y += 81
         if y > 13:
-            b1 += bit(5)
+            b1 |= 0x20
             y -= 27
         if y < -13:
-            b1 += bit(4)
+            b1 |= 0x10
             y += 27
         if y > 4:
-            b0 += bit(5)
+            b0 |= 0x20
             y -= 9
         if y < -4:
-            b0 += bit(4)
+            b0 |= 0x10
             y += 9
         if y > 1:
-            b1 += bit(7)
+            b1 |= 0x80
             y -= 3
         if y < -1:
-            b1 += bit(6)
+            b1 |= 0x40
             y += 3
         if y > 0:
-            b0 += bit(7)
+            b0 |= 0x80
             y -= 1
         if y < 0:
-            b0 += bit(6)
+            b0 |= 0x40
             y += 1
-        if y != 0:
-            raise ValueError(
-                "The dy value given to the writer exceeds maximum allowed."
-            )
-    elif flags == COLOR_CHANGE:
-        b2 = 0b11000011
-    elif flags == STOP:
-        b2 = 0b11000011
-    elif flags == END:
-        b2 = 0b11110011
-    elif flags == SEQUIN_MODE:
-        b2 = 0b01000011
-    return bytes(bytearray([b0, b1, b2]))
+    return bytes((b0, b1, b2))
 
 
 def write(pattern: EmbPattern, f: BinaryIO, settings=None):
@@ -168,21 +277,49 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None):
     stitches = pattern.stitches
     xx = 0
     yy = 0
+    chunks = []
+    chunks_append = chunks.append
+    # Ensure LUTs are built (lazy init)
+    _ensure_luts()
+    assert _STITCH_LUT is not None
+    assert _JUMP_LUT is not None
+    # Local refs for hot loop
+    _stitch_lut = _STITCH_LUT
+    _jump_lut = _JUMP_LUT
+    _round = round
+    _STITCH = STITCH
+    _TRIM = TRIM
+    _JUMP = JUMP
+    _COMMAND_MASK = COMMAND_MASK
+    _encode = encode_record
     for stitch in stitches:
         x = stitch[0]
         y = stitch[1]
-        data = stitch[2] & COMMAND_MASK
-        dx = int(round(x - xx))
-        dy = int(round(y - yy))
+        data = stitch[2] & _COMMAND_MASK
+        dx = int(_round(x - xx))
+        dy = int(_round(y - yy))
 
         xx += dx
         yy += dy
-        if data == TRIM:
+        if data == _STITCH:
+            rec = _stitch_lut.get((dx, dy))
+            if rec is not None:
+                chunks_append(rec)
+            else:
+                chunks_append(_encode(dx, dy, _STITCH))
+        elif data == _TRIM:
             delta = -4
-            f.write(encode_record(-delta / 2, -delta / 2, JUMP))
+            chunks_append(_jump_lut[(2, 2)])
             for p in range(1, trim_at - 1):
-                f.write(encode_record(delta, delta, JUMP))
+                chunks_append(_jump_lut[(delta, delta)])
                 delta = -delta
-            f.write(encode_record(delta / 2, delta / 2, JUMP))
+            chunks_append(_jump_lut[(int(delta / 2), int(delta / 2))])
+        elif data == _JUMP:
+            rec = _jump_lut.get((dx, dy))
+            if rec is not None:
+                chunks_append(rec)
+            else:
+                chunks_append(_encode(dx, dy, _JUMP))
         else:
-            f.write(encode_record(dx, dy, data))
+            chunks_append(_encode(dx, dy, data))
+    f.write(b"".join(chunks))

--- a/src/pystitch/EmbCompress.py
+++ b/src/pystitch/EmbCompress.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 def expand(data, uncompressed_size=None):
     emb_compress = EmbCompress()
     return emb_compress.decompress(data, uncompressed_size)
@@ -14,8 +17,8 @@ def compress(data):
 class Huffman:
     def __init__(self, lengths=None, value=0):
         self.default_value = value
-        self.lengths = lengths
-        self.table = None
+        self.lengths: Any = lengths
+        self.table: Any = None
         self.table_width = 0
 
     def build_table(self):
@@ -42,10 +45,10 @@ class Huffman:
 class EmbCompress:
     def __init__(self):
         self.bit_position = 0
-        self.input_data = None
-        self.block_elements = None
-        self.character_huffman = None
-        self.distance_huffman = None
+        self.input_data: Any = None
+        self.block_elements: Any = None
+        self.character_huffman: Any = None
+        self.distance_huffman: Any = None
 
     def get_bits(self, start_pos_in_bits, length):
         end_pos_in_bits = start_pos_in_bits + length - 1

--- a/src/pystitch/EmbEncoder.py
+++ b/src/pystitch/EmbEncoder.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any
 
 from .EmbFunctions import *
 from .EmbMatrix import EmbMatrix
@@ -67,12 +68,12 @@ class Transcoder:
         rotate = settings.get("rotate", None)
         if rotate is not None:
             self.matrix.post_rotate(rotate)
-        self.source_pattern = None
-        self.destination_pattern = None
+        self.source_pattern: Any = None
+        self.destination_pattern: Any = None
         self.position = 0
         self.order_index = -1
         self.change_sequence = {}
-        self.stitch = None
+        self.stitch: Any = None
         self.state_trimmed = True
         self.state_sequin_mode = False
         self.state_jumping = False
@@ -122,7 +123,7 @@ class Transcoder:
 
     def build_thread_change_sequence(self):
         """Builds a change sequence to plan out all the color changes for the file."""
-        change_sequence = {}
+        change_sequence: dict[int, list[Any]] = {}
         lookahead_index = 0
         change_sequence[0] = [None, None, None, None]
         for (
@@ -137,7 +138,7 @@ class Transcoder:
                     try:
                         current = change_sequence[lookahead_index]
                     except KeyError:
-                        current = [None, None, None, None]
+                        current: list[Any] = [None, None, None, None]
                         change_sequence[lookahead_index] = current
                     lookahead_index += 1
                 else:
@@ -147,10 +148,11 @@ class Transcoder:
                         current = [None, None, None, None]
                         change_sequence[order] = current
             else:
+                assert current_index is not None
                 try:
                     current = change_sequence[current_index]
                 except KeyError:
-                    current = [None, None, None, None]
+                    current: list[Any] = [None, None, None, None]
                     change_sequence[current_index] = current
                 if current_index >= lookahead_index:
                     lookahead_index = current_index + 1
@@ -197,20 +199,35 @@ class Transcoder:
         if self.thread_change_command == NEEDLE_SET:
             self.destination_pattern.threadlist.extend(self.source_pattern.threadlist)
 
+        # Cache matrix coefficients and constants for the hot loop
+        m = self.matrix.m
+        m0, m1, m3, m4, m6, m7 = m[0], m[1], m[3], m[4], m[6], m[7]
+        _round_flag = self.round
+        _round = round
+        _COMMAND_MASK = COMMAND_MASK
+        _FLAGS_MASK = FLAGS_MASK
+        _NO_COMMAND = NO_COMMAND
+        _STITCH = STITCH
+        _NEEDLE_AT = NEEDLE_AT
+        _SEW_TO = SEW_TO
+        _STITCH_FLAG = STITCH  # For inlined stitch_at
+        _dest_stitches = self.destination_pattern.stitches
+
         flags = NO_COMMAND
         for self.position, self.stitch in enumerate(source):
-            p = self.matrix.point_in_matrix_space(self.stitch)
-            x = p[0]
-            y = p[1]
-            if self.round:
-                x = round(x)
-                y = round(y)
-            flags = self.stitch[2] & COMMAND_MASK
-            self.high_flags = self.stitch[2] & FLAGS_MASK
+            s0 = self.stitch[0]
+            s1 = self.stitch[1]
+            x = s0 * m0 + s1 * m3 + m6
+            y = s0 * m1 + s1 * m4 + m7
+            if _round_flag:
+                x = _round(x)
+                y = _round(y)
+            flags = self.stitch[2] & _COMMAND_MASK
+            self.high_flags = self.stitch[2] & _FLAGS_MASK
 
-            if flags == NO_COMMAND:
+            if flags == _NO_COMMAND:
                 continue
-            elif flags == STITCH:
+            elif flags == _STITCH:
                 if self.state_trimmed:
                     self.declare_not_trimmed()
                     self.jump_to_within_stitchrange(x, y)
@@ -221,7 +238,7 @@ class Transcoder:
                     self.state_jumping = False
                 else:
                     self.stitch_with_contingency(x, y)
-            elif flags == NEEDLE_AT:
+            elif flags == _NEEDLE_AT:
                 if self.state_trimmed:
                     self.declare_not_trimmed()
                     self.jump_to_within_stitchrange(x, y)
@@ -231,8 +248,18 @@ class Transcoder:
                     self.needle_to(x, y)
                     self.state_jumping = False
                 else:
-                    self.needle_to(x, y)
-            elif flags == SEW_TO:
+                    # Fast path: inline needle_to + stitch_at for common case
+                    nx = self.needle_x
+                    ny = self.needle_y
+                    ml = self.max_stitch
+                    if abs(x - nx) <= ml and abs(y - ny) <= ml:
+                        # No gap stitches needed - inline add + update
+                        _dest_stitches.append([x, y, _STITCH_FLAG | self.high_flags])
+                        self.needle_x = x
+                        self.needle_y = y
+                    else:
+                        self.needle_to(x, y)
+            elif flags == _SEW_TO:
                 if self.state_trimmed:
                     self.declare_not_trimmed()
                     self.jump_to_within_stitchrange(x, y)

--- a/src/pystitch/EmbPattern.py
+++ b/src/pystitch/EmbPattern.py
@@ -1,18 +1,17 @@
 import os
 
-from .EmbEncoder import Transcoder as Normalizer
 from .EmbFunctions import *
 from .EmbThread import EmbThread
 
 
 class EmbPattern:
     def __init__(self, *args, **kwargs):
-        self.stitches = []  # type: list
-        self.threadlist = []  # type: list
-        self.extras = {}  # type: dict
+        self.stitches: list = []
+        self.threadlist: list = []
+        self.extras: dict = {}
         # filename, name, category, author, keywords, comments, are typical
-        self._previousX = 0  # type: float
-        self._previousY = 0  # type: float
+        self._previousX: float = 0
+        self._previousY: float = 0
         len_args = len(args)
         if len_args >= 1:
             arg0 = args[0]
@@ -72,7 +71,7 @@ class EmbPattern:
     def __deepcopy__(self):
         return self.copy()
 
-    def __iadd__(self, other):
+    def __iadd__(self, other) -> "EmbPattern":
         if isinstance(other, EmbPattern):
             self.add_pattern(other)
         elif isinstance(other, EmbThread) or isinstance(other, str):
@@ -86,7 +85,7 @@ class EmbPattern:
             self.add_command(other)
         elif isinstance(other, list) or isinstance(other, tuple):  # tuple or list
             if len(other) == 0:
-                return
+                return self
             v = other[0]
             if isinstance(v, list) or isinstance(
                 v, tuple
@@ -423,7 +422,7 @@ class EmbPattern:
         while len(self.threadlist) < thread_index:
             self.add_thread(self.get_thread_or_filler(len(self.threadlist)))
 
-    def add_stitch_absolute(self, cmd, x=0, y=0):
+    def add_stitch_absolute(self, cmd, x: float = 0, y: float = 0):
         """Add a command at the absolute location: x, y"""
         self.stitches.append([x, y, cmd])
         self._previousX = x
@@ -541,11 +540,13 @@ class EmbPattern:
             if dy is None:
                 dy = 0
             self.add_command(MATRIX_TRANSLATE, dx, dy)
-        if sx is not None or sx is not None:
+        if sx is not None or sy is not None:
             if sx is None:
                 sx = sy
             if sy is None:
                 sy = sx
+            assert sx is not None
+            assert sy is not None
             self.add_command(MATRIX_SCALE, sx, sy)
         if rotate is not None:
             self.add_command(MATRIX_ROTATE, rotate)
@@ -635,6 +636,7 @@ class EmbPattern:
             ):
                 if mode == 3:
                     del self.stitches[sequence_start_position:position]
+                    assert sequence_start_position is not None
                     position = sequence_start_position
                     self.stitches.insert(position, [stop_x, stop_y, FRAME_EJECT])
                     ie = len(self.stitches)
@@ -653,6 +655,7 @@ class EmbPattern:
             position += 1
         if mode >= 2:  # Frame_eject at end.
             del self.stitches[sequence_start_position:position]
+            assert sequence_start_position is not None
             position = sequence_start_position
             self.stitches.insert(position, [stop_x, stop_y, FRAME_EJECT])
 
@@ -785,6 +788,7 @@ class EmbPattern:
     def get_normalized_pattern(self, encode_settings=None):
         """Encodes pattern typically for saving."""
         normal_pattern = EmbPattern()
+        from .EmbEncoder import Transcoder as Normalizer
         transcoder = Normalizer(encode_settings)
         transcoder.transcode(self, normal_pattern)
         return normal_pattern
@@ -843,57 +847,57 @@ class EmbPattern:
             encode = True
 
         if settings.get("encode", encode):
-            if not ("max_jump" in settings):
+            if "max_jump" not in settings:
                 try:
                     settings["max_jump"] = writer.MAX_JUMP_DISTANCE
                 except AttributeError:
                     pass
-            if not ("max_stitch" in settings):
+            if "max_stitch" not in settings:
                 try:
                     settings["max_stitch"] = writer.MAX_STITCH_DISTANCE
                 except AttributeError:
                     pass
-            if not ("full_jump" in settings):
+            if "full_jump" not in settings:
                 try:
                     settings["full_jump"] = writer.FULL_JUMP
                 except AttributeError:
                     pass
-            if not ("round" in settings):
+            if "round" not in settings:
                 try:
                     settings["round"] = writer.ROUND
                 except AttributeError:
                     pass
-            if not ("writes_speeds" in settings):
+            if "writes_speeds" not in settings:
                 try:
                     settings["writes_speeds"] = writer.WRITES_SPEEDS
                 except AttributeError:
                     pass
-            if not ("sequin_contingency" in settings):
+            if "sequin_contingency" not in settings:
                 try:
                     settings["sequin_contingency"] = writer.SEQUIN_CONTINGENCY
                 except AttributeError:
                     pass
-            if not ("thread_change_command" in settings):
+            if "thread_change_command" not in settings:
                 try:
                     settings["thread_change_command"] = writer.THREAD_CHANGE_COMMAND
                 except AttributeError:
                     pass
-            if not ("explicit_trim" in settings):
+            if "explicit_trim" not in settings:
                 try:
                     settings["explicit_trim"] = writer.EXPLICIT_TRIM
                 except AttributeError:
                     pass
-            if not ("translate" in settings):
+            if "translate" not in settings:
                 try:
                     settings["translate"] = writer.TRANSLATE
                 except AttributeError:
                     pass
-            if not ("scale" in settings):
+            if "scale" not in settings:
                 try:
                     settings["scale"] = writer.SCALE
                 except AttributeError:
                     pass
-            if not ("rotate" in settings):
+            if "rotate" not in settings:
                 try:
                     settings["rotate"] = writer.ROTATE
                 except AttributeError:

--- a/src/pystitch/EmbThread.py
+++ b/src/pystitch/EmbThread.py
@@ -1,3 +1,6 @@
+from typing import Any, Optional
+
+
 def build_unique_palette(thread_palette, threadlist):
     """Turns a threadlist into a unique index list with the thread palette"""
     chart = [None] * len(thread_palette)  # Create a lookup chart.
@@ -43,7 +46,7 @@ def build_nonrepeat_palette(thread_palette, threadlist):
     return palette
 
 
-def find_nearest_color_index(find_color, values):
+def find_nearest_color_index(find_color: Any, values: Any) -> Any:
     if isinstance(find_color, EmbThread):
         find_color = find_color.color
     red = (find_color >> 16) & 0xFF
@@ -67,13 +70,14 @@ def color_rgb(r, g, b):
     return int(((r & 255) << 16) | ((g & 255) << 8) | (b & 255))
 
 
-def color_hex(hex_string):
+def color_hex(hex_string: str) -> int:
     h = hex_string.lstrip("#")
     size = len(h)
     if size == 6 or size == 8:
         return int(h[:6], 16)
     elif size == 4 or size == 3:
         return int(h[0] + h[0] + h[1] + h[1] + h[2] + h[2], 16)
+    return 0
 
 
 def color_distance_red_mean(r1, g1, b1, r2, g2, b2):
@@ -101,13 +105,13 @@ class EmbThread:
         chart=None,
         weight=None,
     ):
-        self.color = 0x000000
-        self.description = description  # type: str
-        self.catalog_number = catalog_number  # type: str
-        self.details = details  # type: str
-        self.brand = brand  # type: str
-        self.chart = chart  # type: str
-        self.weight = weight  # type: str
+        self.color: int = 0x000000
+        self.description: Optional[str] = description
+        self.catalog_number: Optional[str] = catalog_number
+        self.details: Optional[str] = details
+        self.brand: Optional[str] = brand
+        self.chart: Optional[str] = chart
+        self.weight: Optional[str] = weight
         # description, catalog_number, details, brand, chart, weight
         if thread is not None:
             self.set(thread)

--- a/src/pystitch/ExpReader.py
+++ b/src/pystitch/ExpReader.py
@@ -5,36 +5,53 @@ from .ReadHelper import signed8
 
 
 def read_exp_stitches(f: BinaryIO, out: EmbPattern):
-    while True:
-        b = bytearray(f.read(2))
-        if len(b) != 2:
-            break
-        if b[0] != 0x80:
-            x = signed8(b[0])
-            y = -signed8(b[1])
-            out.stitch(x, y)
+    # Bulk-read all stitch data
+    raw = f.read()
+    data_len = len(raw)
+    if data_len < 2:
+        out.end()
+        return
+
+    # Local references for speed
+    stitch = out.stitch
+    move = out.move
+    trim_fn = out.trim
+    color_change = out.color_change
+
+    offset = 0
+    while offset <= data_len - 2:
+        b0 = raw[offset]
+        b1 = raw[offset + 1]
+        offset += 2
+
+        if b0 != 0x80:
+            x = signed8(b0)
+            y = -signed8(b1)
+            stitch(x, y)
             continue
 
-        control = b[1]
-        b = bytearray(f.read(2))  # 07 00
-        if len(b) != 2:
+        control = b1
+        if offset > data_len - 2:
             break
-        x = signed8(b[0])
-        y = -signed8(b[1])
+        b0 = raw[offset]
+        b1 = raw[offset + 1]
+        offset += 2
+
+        x = signed8(b0)
+        y = -signed8(b1)
         if control == 0x80:  # Trim
-            out.trim()
+            trim_fn()
             continue
         elif control == 0x02:
-            out.stitch(x, y)
-            # This shouldn't exist.
+            stitch(x, y)
             continue
         elif control == 0x04:  # Jump
-            out.move(x, y)
+            move(x, y)
             continue
         elif control == 0x01:  # Colorchange
-            out.color_change()
+            color_change()
             if x != 0 or y != 0:
-                out.move(x, y)
+                move(x, y)
             continue
         break  # Uncaught Control
     out.end()

--- a/src/pystitch/ExpWriter.py
+++ b/src/pystitch/ExpWriter.py
@@ -42,4 +42,5 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None):
             f.write(b"\x80\x01\x00\x00")
             continue
         elif data == END:
-            pass
+            f.write(b"\x80\x10")
+            break

--- a/src/pystitch/HusReader.py
+++ b/src/pystitch/HusReader.py
@@ -9,25 +9,25 @@ from .ReadHelper import (read_int_16le, read_int_32le, read_string_8, signed8,
 
 
 def read(f: BinaryIO, out: EmbPattern, settings=None):
-    magic_code = read_int_32le(f)
+    _magic_code = read_int_32le(f)
     number_of_stitches = read_int_32le(f)
     number_of_colors = read_int_32le(f)
 
     if number_of_stitches == 0:
         raise NoStitchesError('No stitches found, the file appears to be corrupted.')
 
-    extend_pos_x = signed16(read_int_16le(f))
-    extend_pos_y = signed16(read_int_16le(f))
-    extend_neg_x = signed16(read_int_16le(f))
-    extend_neg_y = signed16(read_int_16le(f))
+    _extend_pos_x = signed16(read_int_16le(f))
+    _extend_pos_y = signed16(read_int_16le(f))
+    _extend_neg_x = signed16(read_int_16le(f))
+    _extend_neg_y = signed16(read_int_16le(f))
 
     command_offset = read_int_32le(f)
     x_offset = read_int_32le(f)
     y_offset = read_int_32le(f)
 
-    string_value = read_string_8(f, 8)
+    _string_value = read_string_8(f, 8)
 
-    unknown_16_bit = read_int_16le(f)
+    _unknown_16_bit = read_int_16le(f)
 
     hus_thread_set = get_thread_set()
     for i in range(0, number_of_colors):

--- a/src/pystitch/InbReader.py
+++ b/src/pystitch/InbReader.py
@@ -35,3 +35,4 @@ def read_inb_stitches(f: BinaryIO, out: EmbPattern):
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     f.seek(0x2000, 0)
     read_inb_stitches(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/InfReader.py
+++ b/src/pystitch/InfReader.py
@@ -6,9 +6,9 @@ from .ReadHelper import read_int_16be, read_int_32be
 
 
 def read(f: BinaryIO, out: EmbPattern, settings=None):
-    u0 = read_int_32be(f)
-    u1 = read_int_32be(f)
-    u2 = read_int_32be(f)
+    _u0 = read_int_32be(f)
+    _u1 = read_int_32be(f)
+    _u2 = read_int_32be(f)
     number_of_colors = read_int_32be(f)
     for j in range(0, number_of_colors):
         length = read_int_16be(f) - 2  # 2 bytes of the length.

--- a/src/pystitch/InkstitchGcodeWriter.py
+++ b/src/pystitch/InkstitchGcodeWriter.py
@@ -1,4 +1,3 @@
-import math
 from typing import BinaryIO
 from itertools import cycle
 
@@ -27,7 +26,7 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None):
     custom_stitch = settings.get('custom_stitch', '')
     custom_jump = settings.get('custom_jump', '')
     custom_color_change = settings.get('custom_color_change', '')
-    custom_frameout = settings.get('custom_frameout', '')
+    settings.get('custom_frameout', '')
     custom_stop = settings.get('custom_stop', '')
     custom_start = settings.get('custom_start', '')
     custom_end = settings.get('custom_end', '')

--- a/src/pystitch/JefReader.py
+++ b/src/pystitch/JefReader.py
@@ -6,39 +6,56 @@ from .ReadHelper import read_int_32le, signed8
 
 
 def read_jef_stitches(f: BinaryIO, out: EmbPattern, settings=None):
+    # Bulk-read all remaining stitch data
+    raw = f.read()
+    data_len = len(raw)
+    if data_len < 2:
+        out.end(0, 0)
+        return
+
+    # Local references for speed
+    stitch = out.stitch
+    move = out.move
+    trim_fn = out.trim
+    color_change = out.color_change
+    stop = out.stop
+    threadlist = out.threadlist
+
     color_index = 1
-    while True:
-        b = bytearray(f.read(2))
-        if len(b) != 2:
-            break
-        if b[0] != 0x80:
-            x = signed8(b[0])
-            y = -signed8(b[1])
-            out.stitch(x, y)
+    offset = 0
+
+    while offset <= data_len - 2:
+        b0 = raw[offset]
+        b1 = raw[offset + 1]
+        offset += 2
+
+        if b0 != 0x80:
+            x = signed8(b0)
+            y = -signed8(b1)
+            stitch(x, y)
             continue
-        ctrl = b[1]
-        b = bytearray(f.read(2))
-        if len(b) != 2:
+
+        ctrl = b1
+        if offset > data_len - 2:
             break
-        x = signed8(b[0])
-        y = -signed8(b[1])
+        b0 = raw[offset]
+        b1 = raw[offset + 1]
+        offset += 2
+
+        x = signed8(b0)
+        y = -signed8(b1)
         if ctrl == 0x02:
             if x == 0 and y == 0:
-                # My Janome MC400E only trims if there are three jumps in a
-                # row.  However, JEF files found in the wild seem to be written
-                # with the expectation that a single zero-length jump is a
-                # trim, so we read it as such.
-                out.trim(x, y)
+                trim_fn(x, y)
             else:
-                out.move(x, y)
+                move(x, y)
             continue
         if ctrl == 0x01:
-            # PATCH: None means stop since it was color #0
-            if out.threadlist[color_index] is None:
-                out.stop(0, 0)
-                del out.threadlist[color_index]
+            if color_index < len(threadlist) and threadlist[color_index] is None:
+                stop(0, 0)
+                del threadlist[color_index]
             else:
-                out.color_change(0, 0)
+                color_change(0, 0)
                 color_index += 1
             continue
         if ctrl == 0x10:

--- a/src/pystitch/JpxReader.py
+++ b/src/pystitch/JpxReader.py
@@ -46,3 +46,4 @@ def read(f: BinaryIO, out: EmbPattern, settings=None):
         out.add_thread({"color": "random", "name": "JPX index " + str(color_index)})
     f.seek(stitch_start_position, 0)
     read_jpx_stitches(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/MaxReader.py
+++ b/src/pystitch/MaxReader.py
@@ -11,7 +11,7 @@ def read(f: BinaryIO, out: EmbPattern, settings=None):
     stitch_count = read_int_32le(f)
     for i in range(0, stitch_count):
         x = read_int_24le(f)
-        c0 = read_int_8(f)
+        _c0 = read_int_8(f)
         y = read_int_24le(f)
         c1 = read_int_8(f)
         x = signed24(x)

--- a/src/pystitch/MitReader.py
+++ b/src/pystitch/MitReader.py
@@ -42,3 +42,4 @@ def read(f: BinaryIO, out: EmbPattern, settings=None):
             out.stitch(x, y)
         previous_ctrl = ctrl
     out.end()
+    out.interpolate_trims(3)

--- a/src/pystitch/NewReader.py
+++ b/src/pystitch/NewReader.py
@@ -37,3 +37,4 @@ def new_stitch_encoding_read(f: BinaryIO, out: EmbPattern):
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     f.seek(2, 1)  # stitchcount.
     new_stitch_encoding_read(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/PcdReader.py
+++ b/src/pystitch/PcdReader.py
@@ -14,8 +14,8 @@ PC_SIZE_CONVERSION_RATIO = 5.0 / 3.0
 
 
 def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
-    version = read_int_8(f)
-    hoop_size = read_int_8(f)
+    _version = read_int_8(f)
+    _hoop_size = read_int_8(f)
     # 0 for PCD,
     # 1 for PCQ (MAXI),
     # 2 for PCS small hoop(80x80),
@@ -27,11 +27,11 @@ def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
         out.add_thread(thread)
         f.seek(1, 1)
 
-    stitch_count = read_int_16le(f)
+    _stitch_count = read_int_16le(f)
     while True:
-        c0 = read_int_8(f)
+        _c0 = read_int_8(f)
         x = read_int_24le(f)
-        c1 = read_int_8(f)
+        _c1 = read_int_8(f)
         y = read_int_24le(f)
         ctrl = read_int_8(f)
         if ctrl is None:
@@ -55,3 +55,4 @@ def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
 
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     read_pc_file(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/PcmReader.py
+++ b/src/pystitch/PcmReader.py
@@ -36,12 +36,12 @@ def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
         thread = pcm_threads[color_index]
         out.add_thread(thread)
 
-    stitch_count = read_int_16be(f)
+    _stitch_count = read_int_16be(f)
     while True:
         x = read_int_24be(f)
-        c0 = read_int_8(f)
+        _c0 = read_int_8(f)
         y = read_int_24be(f)
-        c1 = read_int_8(f)
+        _c1 = read_int_8(f)
         ctrl = read_int_8(f)
         if ctrl is None:
             break
@@ -64,3 +64,4 @@ def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
 
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     read_pc_file(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/PcqReader.py
+++ b/src/pystitch/PcqReader.py
@@ -14,8 +14,8 @@ PC_SIZE_CONVERSION_RATIO = 5.0 / 3.0
 
 
 def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
-    version = read_int_8(f)
-    hoop_size = read_int_8(f)
+    _version = read_int_8(f)
+    _hoop_size = read_int_8(f)
     # 0 for PCD,
     # 1 for PCQ (MAXI),
     # 2 for PCS small hoop(80x80),
@@ -27,11 +27,11 @@ def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
         out.add_thread(thread)
         f.seek(1, 1)
 
-    stitch_count = read_int_16le(f)
+    _stitch_count = read_int_16le(f)
     while True:
-        c0 = read_int_8(f)
+        _c0 = read_int_8(f)
         x = read_int_24le(f)
-        c1 = read_int_8(f)
+        _c1 = read_int_8(f)
         y = read_int_24le(f)
         ctrl = read_int_8(f)
         if ctrl is None:
@@ -55,3 +55,4 @@ def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
 
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     read_pc_file(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/PcsReader.py
+++ b/src/pystitch/PcsReader.py
@@ -14,8 +14,8 @@ PC_SIZE_CONVERSION_RATIO = 5.0 / 3.0
 
 
 def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
-    version = read_int_8(f)
-    hoop_size = read_int_8(f)
+    _version = read_int_8(f)
+    _hoop_size = read_int_8(f)
     # 0 for PCD,
     # 1 for PCQ (MAXI),
     # 2 for PCS small hoop(80x80),
@@ -27,11 +27,11 @@ def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
         out.add_thread(thread)
         f.seek(1, 1)
 
-    stitch_count = read_int_16le(f)
+    _stitch_count = read_int_16le(f)
     while True:
-        c0 = read_int_8(f)
+        _c0 = read_int_8(f)
         x = read_int_24le(f)
-        c1 = read_int_8(f)
+        _c1 = read_int_8(f)
         y = read_int_24le(f)
         ctrl = read_int_8(f)
         if ctrl is None:
@@ -55,3 +55,4 @@ def read_pc_file(f: BinaryIO, out: EmbPattern, settings=None):
 
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     read_pc_file(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/PecGraphics.py
+++ b/src/pystitch/PecGraphics.py
@@ -316,8 +316,8 @@ def draw_scaled(extends, points, graphic, stride, buffer=5):
 
 
 def clear(graphic):
-    for b in graphic:
-        b = 0
+    for i in range(len(graphic)):
+        graphic[i] = 0
 
 
 def graphic_mark_bit(graphic, x, y, stride=6):
@@ -338,7 +338,7 @@ def get_graphic_as_string(graphic, one="#", zero=" "):
         graphic = graphic[0]
 
     if isinstance(graphic, str):
-        graphic = bytearray(graphic)
+        graphic = bytearray(graphic, 'latin-1')
 
     list_string = [
         one if (byte >> i) & 1 else zero for byte in graphic for i in range(0, 8)

--- a/src/pystitch/PecReader.py
+++ b/src/pystitch/PecReader.py
@@ -10,7 +10,7 @@ FLAG_LONG = 0x80
 
 
 def read(f: BinaryIO, out: EmbPattern, settings=None):
-    pec_string = read_string_8(f, 8)
+    read_string_8(f, 8)
     # pec_string must equal #PEC0001
     read_pec(f, out)
     out.interpolate_duplicate_color_as_stop()
@@ -114,47 +114,68 @@ def signed7(b):
 
 
 def read_pec_stitches(f: BinaryIO, out: EmbPattern):
-    while True:
-        val1 = read_int_8(f)
-        val2 = read_int_8(f)
+    # Bulk-read all remaining stitch data at once
+    raw = f.read()
+    data_len = len(raw)
+    if data_len < 2:
+        out.end()
+        return
+
+    # Local references for speed
+    stitch = out.stitch
+    move = out.move
+    trim = out.trim
+    color_change = out.color_change
+
+    offset = 0
+    while offset < data_len - 1:
+        val1 = raw[offset]
+        val2 = raw[offset + 1]
+        offset += 2
+
         if (val1 == 0xFF and val2 == 0x00) or val2 is None:
             break
         if val1 == 0xFE and val2 == 0xB0:
-            f.seek(1, 1)
-            out.color_change(0, 0)
+            offset += 1  # skip 1 byte
+            color_change(0, 0)
             continue
+
         jump = False
-        trim = False
+        trim_flag = False
+
         if val1 & FLAG_LONG != 0:
             if val1 & TRIM_CODE != 0:
-                trim = True
+                trim_flag = True
             if val1 & JUMP_CODE != 0:
                 jump = True
             code = (val1 << 8) | val2
             x = signed12(code)
-            val2 = read_int_8(f)
-            if val2 is None:
+            if offset >= data_len:
                 break
+            val2 = raw[offset]
+            offset += 1
         else:
             x = signed7(val1)
 
         if val2 & FLAG_LONG != 0:
             if val2 & TRIM_CODE != 0:
-                trim = True
+                trim_flag = True
             if val2 & JUMP_CODE != 0:
                 jump = True
-            val3 = read_int_8(f)
-            if val3 is None:
+            if offset >= data_len:
                 break
+            val3 = raw[offset]
+            offset += 1
             code = val2 << 8 | val3
             y = signed12(code)
         else:
             y = signed7(val2)
+
         if jump:
-            out.move(x, y)
-        elif trim:
-            out.trim()
-            out.move(x, y)
+            move(x, y)
+        elif trim_flag:
+            trim()
+            move(x, y)
         else:
-            out.stitch(x, y)
+            stitch(x, y)
     out.end()

--- a/src/pystitch/PecWriter.py
+++ b/src/pystitch/PecWriter.py
@@ -49,7 +49,7 @@ def write_pec(pattern: EmbPattern, f: BinaryIO, threadlist=None):
 
 
 def write_pec_header(pattern: EmbPattern, f: BinaryIO, threadlist):
-    name = pattern.get_metadata("name", "Untitled")
+    name = pattern.get_metadata("name") or "Untitled"
     # the usage of other characters can mess up the output file
     name = re.sub('[^A-Za-z0-9]+', '', name) or "Untitled"
     write_string_utf8(f, "LA:%-16s\r" % name[:8])
@@ -163,7 +163,7 @@ def pec_encode(pattern: EmbPattern, f: BinaryIO):
         yy += dy
         if data == STITCH:
             if jumping:
-                if dx != 0 and dy != 0:
+                if dx != 0 or dy != 0:
                     write_stitch(f, 0, 0)
                 jumping = False
             write_stitch(f, dx, dy)
@@ -186,7 +186,9 @@ def pec_encode(pattern: EmbPattern, f: BinaryIO):
         elif data == STOP:
             pass  # These will already be processed into duplicate colors.
         elif data == TRIM:
-            pass
+            # Signal the machine to trim; the next JUMP will provide
+            # the repositioning movement with TRIM_CODE flag.
+            jumping = True
         elif data == END:
             f.write(b"\xff")
             break

--- a/src/pystitch/PesReader.py
+++ b/src/pystitch/PesReader.py
@@ -73,7 +73,7 @@ def read(f: BinaryIO, out: EmbPattern, settings=None):
 
 def read_pes_string(f: BinaryIO):
     length = read_int_8(f)
-    if length == 0:
+    if length is None or length == 0:
         return None
     return read_string_8(f, length)
 

--- a/src/pystitch/PltWriter.py
+++ b/src/pystitch/PltWriter.py
@@ -8,7 +8,6 @@ work and are the typical goal product.
 The standard step size of 1 unit in HPGL is 1/40 mm. As opposed to 1/10 mm which is standard for embroidery. HPGL is
 increasing Y is downwards, which is contrary to most embroidery.
 """
-import sys
 from typing import BinaryIO
 
 from .EmbPattern import EmbPattern
@@ -25,18 +24,17 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None):
     trimmed = True
 
     stitches = pattern.stitches
+    origin_x = stitches[0][0] if stitches else 0
+    origin_y = stitches[0][1] if stitches else 0
     xx = 0
     yy = 0
-
-    # Start point = (0, 0)
-    pattern.translate(-pattern.stitches[0][0], -pattern.stitches[0][1])
 
     pen_id = 1
 
     for stitch in stitches:
         # 4 to convert 1/10mm to 1/40mm.
-        x = stitch[0] * 4.0
-        y = stitch[1] * 4.0
+        x = (stitch[0] - origin_x) * 4.0
+        y = (stitch[1] - origin_y) * 4.0
         data = stitch[2] & COMMAND_MASK
         dx = int(round(x - xx))
         dy = int(round(y - yy))

--- a/src/pystitch/PmvWriter.py
+++ b/src/pystitch/PmvWriter.py
@@ -15,7 +15,7 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None):
     min_y = +200000000
     point_count = 0
     for stitch in pattern.stitches:
-        data = stitch[2]
+        data = stitch[2] & COMMAND_MASK
         x = stitch[0]
         y = -stitch[1]
         if data == STITCH or data == JUMP:
@@ -50,17 +50,18 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None):
 
     write_int_16le(f, point_count)
     write_int_16le(f, point_count * 2)
-    point_index = -1
+    written = 0
     max_x = -200000000
     min_x = +200000000
     max_y = -200000000
     min_y = +200000000
     xx = 0
     for stitch in pattern.stitches:
-        point_index += 1
-        if point_index >= point_count:
+        if written >= point_count:
             break
         data = stitch[2] & COMMAND_MASK
+        if data != STITCH and data != JUMP:
+            continue
         x = stitch[0]
         y = -stitch[1]
         x *= scale_x
@@ -69,23 +70,22 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None):
         y = int(round(y))
         x = int(round(x - xx))
         xx += x
-        if data == STITCH or data == JUMP:
-            if xx > max_x:
-                max_x = xx
-            if xx < min_x:
-                min_x = xx
-            if y > max_y:
-                max_y = y
-            if y < min_y:
-                min_y = y
+        if xx > max_x:
+            max_x = xx
+        if xx < min_x:
+            min_x = xx
+        if y > max_y:
+            max_y = y
+        if y < min_y:
+            min_y = y
 
-            if x < 0:
-                x += 64
-            if y < 0:
-                y += 32
-            write_int_8(f, x)
-            write_int_8(f, y)
-            continue
+        if x < 0:
+            x += 64
+        if y < 0:
+            y += 32
+        write_int_8(f, x)
+        write_int_8(f, y)
+        written += 1
     write_int_16le(f, 0)
     write_int_16le(f, 256)
     f.write(b"\x00\x00\x00\x00\x05\x00\x00\x00" b"\x00\x00\x00\x00\x00\x00\x02\x00")

--- a/src/pystitch/QccWriter.py
+++ b/src/pystitch/QccWriter.py
@@ -1,6 +1,3 @@
-import sys
-from typing import BinaryIO
-
 from .EmbPattern import EmbPattern
 from .EmbFunctions import *
 from .WriteHelper import write_string_utf8
@@ -11,7 +8,6 @@ TENTH_MM_PER_INCH = 254
 def write(pattern: EmbPattern, stream, settings=None):
     write_string_utf8(stream, "c s\n")
 
-    trimmed = True
 
     stitches = pattern.stitches
     xx = 0
@@ -20,7 +16,6 @@ def write(pattern: EmbPattern, stream, settings=None):
     # Start point = (0, 0)
     pattern.translate(-pattern.stitches[0][0], -pattern.stitches[0][1])
 
-    pen_id = 1
 
     for stitch in stitches:
         # 4 to convert 1/10mm to 1/40mm.

--- a/src/pystitch/ReadHelper.py
+++ b/src/pystitch/ReadHelper.py
@@ -1,111 +1,111 @@
+import struct
+
+_unpack_b = struct.Struct('b').unpack
+_unpack_B = struct.Struct('B').unpack
+_unpack_le_h = struct.Struct('<h').unpack
+_unpack_le_H = struct.Struct('<H').unpack
+_unpack_be_h = struct.Struct('>h').unpack
+_unpack_be_H = struct.Struct('>H').unpack
+_unpack_le_i = struct.Struct('<i').unpack
+_unpack_le_I = struct.Struct('<I').unpack
+_unpack_be_i = struct.Struct('>i').unpack
+_unpack_be_I = struct.Struct('>I').unpack
+
+
 def signed8(b):
     if b > 127:
-        return -256 + b
-    else:
-        return b
+        return b - 256
+    return b
 
 
 def signed16(v):
     v &= 0xFFFF
     if v > 0x7FFF:
-        return -0x10000 + v
-    else:
-        return v
+        return v - 0x10000
+    return v
 
 
 def signed24(v):
     v &= 0xFFFFFF
     if v > 0x7FFFFF:
-        return -0x1000000 + v
-    else:
-        return v
+        return v - 0x1000000
+    return v
 
 
 def read_signed(stream, n):
-    byte = bytearray(stream.read(n))
-    signed_bytes = []
-    for b in byte:
-        signed_bytes.append(signed8(b))
-    return signed_bytes
+    data = stream.read(n)
+    if len(data) != n:
+        return []
+    return list(struct.unpack(f'{n}b', data))
 
 
 def read_sint_8(stream):
-    byte = bytearray(stream.read(1))
-    if len(byte) == 1:
-        return signed8(byte[0])
+    data = stream.read(1)
+    if len(data) == 1:
+        return _unpack_b(data)[0]
     return None
 
 
 def read_int_8(stream):
-    byte = bytearray(stream.read(1))
-    if len(byte) == 1:
-        return byte[0]
+    data = stream.read(1)
+    if len(data) == 1:
+        return data[0]
     return None
 
 
 def read_int_16le(stream):
-    byte = bytearray(stream.read(2))
-    if len(byte) == 2:
-        return (byte[0] & 0xFF) + ((byte[1] & 0xFF) << 8)
+    data = stream.read(2)
+    if len(data) == 2:
+        return _unpack_le_H(data)[0]
     return None
 
 
 def read_int_16be(stream):
-    byte = bytearray(stream.read(2))
-    if len(byte) == 2:
-        return (byte[1] & 0xFF) + ((byte[0] & 0xFF) << 8)
+    data = stream.read(2)
+    if len(data) == 2:
+        return _unpack_be_H(data)[0]
     return None
 
 
 def read_int_24le(stream):
-    b = bytearray(stream.read(3))
-    if len(b) == 3:
-        return (b[0] & 0xFF) + ((b[1] & 0xFF) << 8) + ((b[2] & 0xFF) << 16)
+    data = stream.read(3)
+    if len(data) == 3:
+        return data[0] | (data[1] << 8) | (data[2] << 16)
     return None
 
 
 def read_int_24be(stream):
-    b = bytearray(stream.read(3))
-    if len(b) == 3:
-        return (b[2] & 0xFF) + ((b[1] & 0xFF) << 8) + ((b[0] & 0xFF) << 16)
+    data = stream.read(3)
+    if len(data) == 3:
+        return data[2] | (data[1] << 8) | (data[0] << 16)
     return None
 
 
 def read_int_32le(stream):
-    b = bytearray(stream.read(4))
-    if len(b) == 4:
-        return (
-            (b[0] & 0xFF)
-            + ((b[1] & 0xFF) << 8)
-            + ((b[2] & 0xFF) << 16)
-            + ((b[3] & 0xFF) << 24)
-        )
+    data = stream.read(4)
+    if len(data) == 4:
+        return _unpack_le_I(data)[0]
     return None
 
 
 def read_int_32be(stream):
-    b = bytearray(stream.read(4))
-    if len(b) == 4:
-        return (
-            (b[3] & 0xFF)
-            + ((b[2] & 0xFF) << 8)
-            + ((b[1] & 0xFF) << 16)
-            + ((b[0] & 0xFF) << 24)
-        )
+    data = stream.read(4)
+    if len(data) == 4:
+        return _unpack_be_I(data)[0]
     return None
 
 
 def read_string_8(stream, length):
-    byte = stream.read(length)
+    data = stream.read(length)
     try:
-        return byte.decode("utf8")
-    except UnicodeDecodeError:
-        return None  # Must be > 128 chars.
+        return data.decode("utf8")
+    except (UnicodeDecodeError, AttributeError):
+        return None
 
 
 def read_string_16(stream, length):
-    byte = stream.read(length)
+    data = stream.read(length)
     try:
-        return byte.decode("utf16")
-    except UnicodeDecodeError:
+        return data.decode("utf16")
+    except (UnicodeDecodeError, AttributeError):
         return None

--- a/src/pystitch/SewReader.py
+++ b/src/pystitch/SewReader.py
@@ -20,7 +20,13 @@ def read_sew_stitches(f: BinaryIO, out: EmbPattern):
         if control & 1:
             out.color_change()
             continue
-        if control == 0x04 or control == 0x02:
+        if control == 0x02:
+            if b[0] == 0 and b[1] == 0:
+                out.trim()
+            else:
+                out.move(signed8(b[0]), -signed8(b[1]))
+            continue
+        if control == 0x04:
             out.move(signed8(b[0]), -signed8(b[1]))
             continue
         if control == 0x10:
@@ -40,3 +46,4 @@ def read(f: BinaryIO, out: EmbPattern, settings=None):
 
     f.seek(0x1D78, 0)
     read_sew_stitches(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/ShvReader.py
+++ b/src/pystitch/ShvReader.py
@@ -42,7 +42,7 @@ def read(f: BinaryIO, out: EmbPattern, settings=None):
     current_color_index = 0
     try:
         max_stitches = stitch_per_color[current_color_index]
-    except IndexError:
+    except (KeyError, IndexError):
         max_stitches = 0
     while True:
         flags = STITCH
@@ -79,3 +79,4 @@ def read(f: BinaryIO, out: EmbPattern, settings=None):
         stitches_since_stop += 1
         out.add_stitch_relative(flags, dx, dy)
     out.end()
+    out.interpolate_trims(3)

--- a/src/pystitch/StcReader.py
+++ b/src/pystitch/StcReader.py
@@ -32,3 +32,4 @@ def stc_stitch_encoding_read(f: BinaryIO, out: EmbPattern):
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     f.seek(0x28, 1)  # DESIGN: xxxxxx STITCHES: xxxx.
     stc_stitch_encoding_read(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/StxReader.py
+++ b/src/pystitch/StxReader.py
@@ -8,8 +8,8 @@ from .ReadHelper import read_int_32le
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     # File starts with STX
     f.seek(0x0C, 1)
-    color_start_position = read_int_32le(f)
-    dunno_block_start_position = read_int_32le(f)
+    _color_start_position = read_int_32le(f)
+    _dunno_block_start_position = read_int_32le(f)
     stitch_start_position = read_int_32le(f)
     f.seek(stitch_start_position, 0)
     read_exp_stitches(f, out)

--- a/src/pystitch/TbfReader.py
+++ b/src/pystitch/TbfReader.py
@@ -43,10 +43,7 @@ def read(f: BinaryIO, out: EmbPattern, settings=None):
                 out.needle_change(needle=needle_value)
             continue
         elif ctrl == 0x90:
-            if x == 0 and y == 0:
-                out.trim()
-            else:
-                out.move(signed8(x), -signed8(y))
+            out.move(signed8(x), -signed8(y))
             continue
         elif ctrl == 0x40:
             out.stop()

--- a/src/pystitch/U01Writer.py
+++ b/src/pystitch/U01Writer.py
@@ -16,7 +16,7 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None):
     stitches = pattern.stitches
     stitch_count = len(stitches)
     for i in range(0, 0x80):
-        f.write(b"0")
+        f.write(b"\x00")
     if stitch_count == 0:
         return
     extends = pattern.bounds()

--- a/src/pystitch/Vp3Reader.py
+++ b/src/pystitch/Vp3Reader.py
@@ -50,7 +50,7 @@ def signed16(b0, b1):
 
 
 def read(f: BinaryIO, out: EmbPattern, settings=None):
-    b = f.read(6)
+    f.read(6)
     # magic code: %vsm%\0
     skip_vp3_string(f)  # "Produced by     Software Ltd"
     f.seek(7, 1)
@@ -71,7 +71,7 @@ def read(f: BinaryIO, out: EmbPattern, settings=None):
 
 
 def vp3_read_colorblock(f: BinaryIO, out: EmbPattern, center_x, center_y):
-    bytescheck = f.read(3)  # \x00\x05\x00
+    f.read(3)  # \x00\x05\x00
     distance_to_next_block_050 = read_int_32be(f)
     block_end_position = distance_to_next_block_050 + f.tell()
 
@@ -84,7 +84,7 @@ def vp3_read_colorblock(f: BinaryIO, out: EmbPattern, center_x, center_y):
     thread = vp3_read_thread(f)
     out.add_thread(thread)
     f.seek(15, 1)
-    bytescheck = f.read(3)  # \x0A\xF6\x00
+    f.read(3)  # \x0A\xF6\x00
     stitch_byte_length = block_end_position - f.tell()
     stitch_bytes = read_signed(f, stitch_byte_length)
     i = 0
@@ -113,13 +113,13 @@ def vp3_read_colorblock(f: BinaryIO, out: EmbPattern, center_x, center_y):
 def vp3_read_thread(f: BinaryIO):
     thread = EmbThread()
     colors = read_int_8(f)
-    transition = read_int_8(f)
+    _transition = read_int_8(f)
     for m in range(0, colors):
         thread.color = read_int_24be(f)
-        parts = read_int_8(f)
-        color_length = read_int_16be(f)
-    thread_type = read_int_8(f)
-    weight = read_int_8(f)
+        _parts = read_int_8(f)
+        _color_length = read_int_16be(f)
+    _thread_type = read_int_8(f)
+    _weight = read_int_8(f)
     thread.catalog_number = read_vp3_string_8(f)
     thread.description = read_vp3_string_8(f)
     thread.brand = read_vp3_string_8(f)

--- a/src/pystitch/Vp3Writer.py
+++ b/src/pystitch/Vp3Writer.py
@@ -126,20 +126,20 @@ def write_design_block(f: BinaryIO, extends, colorblocks):
     center_x = extends[2] - half_width
     center_y = extends[3] - half_height
 
-    write_int_32be(f, int(center_x) * 100)  # initial x
-    write_int_32be(f, int(center_y) * -100)  # initial y
+    write_int_32be(f, int(center_x * 100))  # initial x
+    write_int_32be(f, int(center_y * -100))  # initial y
     write_int_8(f, 0)
     write_int_8(f, 0)
     write_int_8(f, 0)
 
     # extends 2
-    write_int_32be(f, int(half_width) * -100)
-    write_int_32be(f, int(half_width) * 100)
-    write_int_32be(f, int(half_height) * -100)
-    write_int_32be(f, int(half_height) * 100)
+    write_int_32be(f, int(half_width * -100))
+    write_int_32be(f, int(half_width * 100))
+    write_int_32be(f, int(half_height * -100))
+    write_int_32be(f, int(half_height * 100))
 
-    write_int_32be(f, int(width) * 100)
-    write_int_32be(f, int(height) * 100)
+    write_int_32be(f, int(width * 100))
+    write_int_32be(f, int(height * 100))
     vp3_write_string_16(f, "")  # This is notes and settings string.
 
     f.write(b"\x64\x64")  # write_int_16be(f, 25700)
@@ -184,16 +184,16 @@ def write_vp3_colorblock(f: BinaryIO, first, center_x, center_y, stitches, threa
         last_pos_y = 0
     start_position_from_center_x = first_pos_x - center_x
     start_position_from_center_y = -(first_pos_y - center_y)
-    write_int_32be(f, int(start_position_from_center_x) * 100)
-    write_int_32be(f, int(start_position_from_center_y) * 100)
+    write_int_32be(f, int(start_position_from_center_x * 100))
+    write_int_32be(f, int(start_position_from_center_y * 100))
 
     vp3_write_thread(f, thread)
 
     block_shift_x = last_pos_x - first_pos_x
     block_shift_y = -(last_pos_y - first_pos_y)
 
-    write_int_32be(f, int(block_shift_x) * 100)
-    write_int_32be(f, int(block_shift_y) * 100)
+    write_int_32be(f, int(block_shift_x * 100))
+    write_int_32be(f, int(block_shift_y * 100))
 
     write_stitches_block(f, stitches, first_pos_x, first_pos_y)
 
@@ -228,6 +228,7 @@ def write_stitches_block(f: BinaryIO, stitches, first_pos_x, first_pos_y):
     f.write(b"\x0A\xF6\x00")
     last_x = first_pos_x
     last_y = first_pos_y
+    trimmed = False
 
     for stitch in stitches:
         x = stitch[0]
@@ -244,6 +245,7 @@ def write_stitches_block(f: BinaryIO, stitches, first_pos_x, first_pos_y):
             continue
         elif flags == TRIM:
             f.write(b"\x80\x03")
+            trimmed = True
             continue
         elif flags == SEQUIN_MODE:
             continue
@@ -252,13 +254,18 @@ def write_stitches_block(f: BinaryIO, stitches, first_pos_x, first_pos_y):
         elif flags == STOP:
             continue
         elif flags == JUMP:
-            # VP3 has no jump commands. These are skipped.
-            # It moves to the relevant location without needing to block the needlebar.
+            # VP3 has no jump commands. Emit a trim marker if not already
+            # trimmed so the machine lifts the needle. The next stitch's
+            # delta from the pre-jump position provides the repositioning.
+            if not trimmed:
+                f.write(b"\x80\x03")
+                trimmed = True
             continue
         dx = int(round(x - last_x))
         dy = int(round(y - last_y))
         last_x += dx
         last_y += dy
+        trimmed = False
         if flags == STITCH:
             if -127 <= dx <= 127 and -127 <= dy <= 127 and alt == 0:
                 write_int_8(f, dx)

--- a/src/pystitch/WriteHelper.py
+++ b/src/pystitch/WriteHelper.py
@@ -1,109 +1,55 @@
 import struct
 
+_pack_B = struct.Struct('B').pack
+_pack_le_H = struct.Struct('<H').pack
+_pack_be_H = struct.Struct('>H').pack
+_pack_le_I = struct.Struct('<I').pack
+_pack_be_I = struct.Struct('>I').pack
+_pack_le_f = struct.Struct('<f').pack
+
 
 def write_int_array_8(stream, int_array):
-    for value in int_array:
-        v = bytes(
-            bytearray(
-                [
-                    value & 0xFF,
-                ]
-            )
-        )
-        stream.write(v)
+    stream.write(bytes(v & 0xFF for v in int_array))
 
 
 def write_int_8(stream, value):
-    v = bytes(
-        bytearray(
-            [
-                value & 0xFF,
-            ]
-        )
-    )
-    stream.write(v)
+    stream.write(_pack_B(value & 0xFF))
 
 
 def write_int_16le(stream, value):
-    v = bytes(
-        bytearray(
-            [
-                (value >> 0) & 0xFF,
-                (value >> 8) & 0xFF,
-            ]
-        )
-    )
-    stream.write(v)
+    stream.write(_pack_le_H(value & 0xFFFF))
 
 
 def write_int_16be(stream, value):
-    v = bytes(
-        bytearray(
-            [
-                (value >> 8) & 0xFF,
-                (value >> 0) & 0xFF,
-            ]
-        )
-    )
-    stream.write(v)
+    stream.write(_pack_be_H(value & 0xFFFF))
 
 
 def write_int_24le(stream, value):
-    v = bytes(
-        bytearray(
-            [
-                (value >> 0) & 0xFF,
-                (value >> 8) & 0xFF,
-                (value >> 16) & 0xFF,
-            ]
-        )
-    )
-    stream.write(v)
+    stream.write(bytes([
+        value & 0xFF,
+        (value >> 8) & 0xFF,
+        (value >> 16) & 0xFF,
+    ]))
 
 
 def write_int_24be(stream, value):
-    v = bytes(
-        bytearray(
-            [
-                (value >> 16) & 0xFF,
-                (value >> 8) & 0xFF,
-                (value >> 0) & 0xFF,
-            ]
-        )
-    )
-    stream.write(v)
+    stream.write(bytes([
+        (value >> 16) & 0xFF,
+        (value >> 8) & 0xFF,
+        value & 0xFF,
+    ]))
 
 
 def write_int_32le(stream, value):
-    v = bytes(
-        bytearray(
-            [
-                (value >> 0) & 0xFF,
-                (value >> 8) & 0xFF,
-                (value >> 16) & 0xFF,
-                (value >> 24) & 0xFF,
-            ]
-        )
-    )
-    stream.write(v)
+    stream.write(_pack_le_I(value & 0xFFFFFFFF))
 
 
 def write_int_32be(stream, value):
-    v = bytes(
-        bytearray(
-            [
-                (value >> 24) & 0xFF,
-                (value >> 16) & 0xFF,
-                (value >> 8) & 0xFF,
-                (value >> 0) & 0xFF,
-            ]
-        )
-    )
-    stream.write(v)
+    stream.write(_pack_be_I(value & 0xFFFFFFFF))
 
 
 def write_float_32le(stream, value):
-    stream.write(struct.pack("<f", float(value)))
+    stream.write(_pack_le_f(float(value)))
 
 
 def write_string(stream, string, encoding="utf8"):

--- a/src/pystitch/ZhsReader.py
+++ b/src/pystitch/ZhsReader.py
@@ -109,3 +109,4 @@ def read(f: BinaryIO, out: EmbPattern, settings=None):
     read_zhs_header(f, out)
     f.seek(stitch_start_position, 0)
     read_zhs_stitches(f, out)
+    out.interpolate_trims(3)

--- a/src/pystitch/ZxyReader.py
+++ b/src/pystitch/ZxyReader.py
@@ -36,5 +36,8 @@ def read_zxy_stitches(f: BinaryIO, out: EmbPattern):
 def read(f: BinaryIO, out: EmbPattern, settings=None):
     f.seek(0x01, 0)
     stitch_start_distance = read_int_16be(f)
+    if stitch_start_distance is None:
+        out.end()
+        return
     f.seek(stitch_start_distance, 1)
     read_zxy_stitches(f, out)

--- a/src/pystitch/__init__.py
+++ b/src/pystitch/__init__.py
@@ -1,101 +1,113 @@
-name = "pystitch"
-
 # items available at the top level (e.g. pystitch.read)
 from .EmbConstant import *
 from .EmbFunctions import *
-from .EmbMatrix import EmbMatrix
+from .EmbMatrix import EmbMatrix as EmbMatrix
 from .EmbPattern import EmbPattern
-from .EmbThread import EmbThread
-from .EmbCompress import compress, expand
-import pystitch.GenericWriter as GenericWriter
+from .EmbThread import EmbThread as EmbThread
+from .EmbCompress import compress as compress, expand as expand
 
 # items available in a sub-heirarchy (e.g. pystitch.PecGraphics.get_graphic_as_string)
-from .PecGraphics import get_graphic_as_string
+from .PecGraphics import get_graphic_as_string as get_graphic_as_string
 from .pystitch import *
 
-import pystitch.A10oReader as A10oReader
-import pystitch.A100Reader as A100Reader
-# pystitch.ArtReader as ArtReader
-import pystitch.BroReader as BroReader
-import pystitch.ColReader as ColReader
-import pystitch.ColWriter as ColWriter
-import pystitch.CsvReader as CsvReader
-import pystitch.CsvWriter as CsvWriter
-import pystitch.DatReader as DatReader
-import pystitch.DsbReader as DsbReader
-import pystitch.DstReader as DstReader
-import pystitch.DstWriter as DstWriter
-import pystitch.DszReader as DszReader
-import pystitch.EdrReader as EdrReader
-import pystitch.EdrWriter as EdrWriter
-import pystitch.EmdReader as EmdReader
-import pystitch.ExpReader as ExpReader
-import pystitch.ExpWriter as ExpWriter
-import pystitch.ExyReader as ExyReader
-import pystitch.FxyReader as FxyReader
-import pystitch.GcodeReader as GcodeReader
-import pystitch.GcodeWriter as GcodeWriter
-import pystitch.InkstitchGcodeWriter as InkstitchGcodeWriter
-import pystitch.GtReader as GtReader
-import pystitch.HusReader as HusReader
-import pystitch.InbReader as InbReader
-import pystitch.InfReader as InfReader
-import pystitch.InfWriter as InfWriter
-import pystitch.IqpReader as IqpReader
-import pystitch.JefReader as JefReader
-import pystitch.JefWriter as JefWriter
-import pystitch.JpxReader as JpxReader
-import pystitch.JsonReader as JsonReader
-import pystitch.JsonWriter as JsonWriter
-import pystitch.KsmReader as KsmReader
-import pystitch.MaxReader as MaxReader
-import pystitch.MitReader as MitReader
-import pystitch.NewReader as NewReader
-import pystitch.PcdReader as PcdReader
-import pystitch.PcmReader as PcmReader
-import pystitch.PcqReader as PcqReader
-import pystitch.PcsReader as PcsReader
-import pystitch.PecReader as PecReader
-import pystitch.PecWriter as PecWriter
-import pystitch.PesReader as PesReader
-import pystitch.PesWriter as PesWriter
-import pystitch.PhbReader as PhbReader
-import pystitch.PhcReader as PhcReader
-import pystitch.PltReader as PltReader
-import pystitch.PltWriter as PltWriter
-import pystitch.PmvReader as PmvReader
-import pystitch.PmvWriter as PmvWriter
-import pystitch.PngWriter as PngWriter
-import pystitch.QccReader as QccReader
-import pystitch.QccWriter as QccWriter
-import pystitch.SewReader as SewReader
-import pystitch.ShvReader as ShvReader
-import pystitch.SpxReader as SpxReader
-import pystitch.StcReader as StcReader
-import pystitch.StxReader as StxReader
-import pystitch.SvgWriter as SvgWriter
-import pystitch.TapReader as TapReader
-import pystitch.TbfReader as TbfReader
-import pystitch.TbfWriter as TbfWriter
-import pystitch.TxtWriter as TxtWriter
-import pystitch.U01Reader as U01Reader
-import pystitch.U01Writer as U01Writer
-import pystitch.Vp3Reader as Vp3Reader
-import pystitch.Vp3Writer as Vp3Writer
-import pystitch.XxxReader as XxxReader
-import pystitch.XxxWriter as XxxWriter
-import pystitch.ZhsReader as ZhsReader
-import pystitch.ZxyReader as ZxyReader
+# Lazy-load readers/writers on first access
+import importlib as _importlib
 
+name = "pystitch"
+
+_LAZY_MODULES = {
+    'GenericWriter', 'A10oReader', 'A100Reader', 'BroReader',
+    'ColReader', 'ColWriter', 'CsvReader', 'CsvWriter',
+    'DatReader', 'DsbReader', 'DstReader', 'DstWriter',
+    'DszReader', 'EdrReader', 'EdrWriter', 'EmdReader',
+    'ExpReader', 'ExpWriter', 'ExyReader', 'FxyReader',
+    'GcodeReader', 'GcodeWriter', 'InkstitchGcodeWriter',
+    'GtReader', 'HusReader', 'InbReader', 'InfReader', 'InfWriter',
+    'IqpReader', 'JefReader', 'JefWriter', 'JpxReader',
+    'JsonReader', 'JsonWriter', 'KsmReader', 'MaxReader',
+    'MitReader', 'NewReader', 'PcdReader', 'PcmReader',
+    'PcqReader', 'PcsReader', 'PecReader', 'PecWriter',
+    'PesReader', 'PesWriter', 'PhbReader', 'PhcReader',
+    'PltReader', 'PltWriter', 'PmvReader', 'PmvWriter',
+    'PngWriter', 'QccReader', 'QccWriter', 'SewReader',
+    'ShvReader', 'SpxReader', 'StcReader', 'StxReader',
+    'SvgWriter', 'TapReader', 'TbfReader', 'TbfWriter',
+    'TxtWriter', 'U01Reader', 'U01Writer', 'Vp3Reader',
+    'Vp3Writer', 'XxxReader', 'XxxWriter', 'ZhsReader', 'ZxyReader',
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_MODULES:
+        mod = _importlib.import_module(f'.{name}', __name__)
+        globals()[name] = mod
+        return mod
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# Extension-to-module mapping for fast read/write dispatch (no eager imports)
+_EXT_READER = {
+    'pec': 'PecReader', 'pes': 'PesReader', 'exp': 'ExpReader',
+    'dst': 'DstReader', 'jef': 'JefReader', 'vp3': 'Vp3Reader',
+    'csv': 'CsvReader', 'xxx': 'XxxReader', 'sew': 'SewReader',
+    'u00': 'U01Reader', 'u01': 'U01Reader', 'u02': 'U01Reader',
+    'shv': 'ShvReader', '10o': 'A10oReader', '100': 'A100Reader', 'a100': 'A100Reader',
+    'bro': 'BroReader', 'dat': 'DatReader', 'dsb': 'DsbReader',
+    'dsz': 'DszReader', 'emd': 'EmdReader',
+    'e00': 'ExyReader', 'e01': 'ExyReader', 'e02': 'ExyReader',
+    'exy': 'ExyReader',
+    'f00': 'FxyReader', 'f01': 'FxyReader', 'f02': 'FxyReader',
+    'fxy': 'FxyReader',
+    'gt': 'GtReader', 'inb': 'InbReader', 'tbf': 'TbfReader',
+    'ksm': 'KsmReader', 'tap': 'TapReader', 'spx': 'SpxReader',
+    'stx': 'StxReader', 'phb': 'PhbReader', 'phc': 'PhcReader',
+    'new': 'NewReader', 'max': 'MaxReader', 'mit': 'MitReader',
+    'pcd': 'PcdReader', 'pcq': 'PcqReader', 'pcm': 'PcmReader',
+    'pcs': 'PcsReader', 'jpx': 'JpxReader', 'stc': 'StcReader',
+    'zhs': 'ZhsReader',
+    'z00': 'ZxyReader', 'z01': 'ZxyReader', 'z02': 'ZxyReader',
+    'zxy': 'ZxyReader',
+    'pmv': 'PmvReader', 'gcode': 'GcodeReader', 'g-code': 'GcodeReader',
+    'ngc': 'GcodeReader', 'nc': 'GcodeReader', '.g': 'GcodeReader',
+    'hus': 'HusReader', 'iqp': 'IqpReader', 'plt': 'PltReader',
+    'qcc': 'QccReader', 'edr': 'EdrReader', 'col': 'ColReader',
+    'inf': 'InfReader', 'json': 'JsonReader',
+}
+_EXT_WRITER = {
+    'pec': 'PecWriter', 'pes': 'PesWriter', 'exp': 'ExpWriter',
+    'dst': 'DstWriter', 'jef': 'JefWriter', 'vp3': 'Vp3Writer',
+    'svg': 'SvgWriter', 'svgz': 'SvgWriter', 'csv': 'CsvWriter',
+    'xxx': 'XxxWriter', 'u00': 'U01Writer', 'u01': 'U01Writer',
+    'u02': 'U01Writer', 'tbf': 'TbfWriter', 'pmv': 'PmvWriter',
+    'png': 'PngWriter', 'txt': 'TxtWriter',
+    'gcode': 'InkstitchGcodeWriter', 'g-code': 'InkstitchGcodeWriter',
+    'ngc': 'InkstitchGcodeWriter', 'nc': 'InkstitchGcodeWriter',
+    '.g': 'InkstitchGcodeWriter',
+    'plt': 'PltWriter', 'qcc': 'QccWriter',
+    'edr': 'EdrWriter', 'col': 'ColWriter', 'inf': 'InfWriter',
+    'json': 'JsonWriter',
+}
+
+def _get_reader(ext):
+    name = _EXT_READER.get(ext)
+    if name is None:
+        return None
+    mod = __getattr__(name)
+    return mod
+
+def _get_writer(ext):
+    name = _EXT_WRITER.get(ext)
+    if name is None:
+        return None
+    mod = __getattr__(name)
+    return mod
 
 def read(filename, settings=None, pattern=None):
     """Reads file, assuming type by extension"""
     extension = EmbPattern.get_extension_by_filename(filename)
     extension = extension.lower()
-    for file_type in supported_formats():
-        if file_type["extension"] != extension:
-            continue
-        reader = file_type.get("reader", None)
+    reader = _get_reader(extension)
+    if reader is not None:
         return EmbPattern.read_embroidery(reader, filename, settings, pattern)
     return None
 
@@ -104,24 +116,19 @@ def write(pattern, filename, settings=None):
     """Writes file, assuming type by extension"""
     extension = EmbPattern.get_extension_by_filename(filename)
     extension = extension.lower()
-    supported_extensions = [file_type["extension"] for file_type in supported_formats()]
-
-    if extension not in supported_extensions:
-        raise IOError("Conversion to file type '{extension}' is not supported".format(extension=extension))
-
-    ext_to_file_type_lookup = {file_type["extension"]: file_type for file_type in supported_formats()}
-    writer = ext_to_file_type_lookup[extension].get("writer")
-
-    if writer:
+    writer = _get_writer(extension)
+    if writer is not None:
         EmbPattern.write_embroidery(writer, pattern, filename, settings)
-    else:
-        raise IOError("No supported writer found.")
+        return
+    raise IOError("Conversion to file type '{extension}' is not supported".format(extension=extension))
 
 def convert(filename_from, filename_to, settings=None):
     pattern = read(filename_from, settings)
     if pattern is None:
         return
     write(pattern, filename_to, settings)
+
+_supported_formats_cache = None
 
 def supported_formats():
     """Generates dictionary entries for supported formats. Each entry will
@@ -133,13 +140,26 @@ def supported_formats():
 
     Options provides accepted options by the format and their accepted values.
     """
+    global _supported_formats_cache
+    if _supported_formats_cache is not None:
+        return _supported_formats_cache
+    _supported_formats_cache = list(_generate_supported_formats())
+    return _supported_formats_cache
+
+def _generate_supported_formats():
+    # Helper to lazy-resolve reader/writer modules
+    def _r(name):
+        g = globals()
+        if name not in g:
+            __getattr__(name)
+        return g[name]
     # yield ({
     #     "description": "Art Embroidery Format",
     #     "extension": "art",
     #     "extensions": ("art",),
     #     "mimetype": "application/x-art",
     #     "category": "embroidery",
-    #     "reader": ArtReader,
+    #     "reader": _r('ArtReader'),
     #     "metadata": ("name")
     # })
     yield (
@@ -149,8 +169,8 @@ def supported_formats():
             "extensions": ("pec",),
             "mimetype": "application/x-pec",
             "category": "embroidery",
-            "reader": PecReader,
-            "writer": PecWriter,
+            "reader": _r('PecReader'),
+            "writer": _r('PecWriter'),
             "metadata": ("name"),
         }
     )
@@ -161,8 +181,8 @@ def supported_formats():
             "extensions": ("pes",),
             "mimetype": "application/x-pes",
             "category": "embroidery",
-            "reader": PesReader,
-            "writer": PesWriter,
+            "reader": _r('PesReader'),
+            "writer": _r('PesWriter'),
             "versions": ("1", "6", "1t", "6t"),
             "metadata": ("name", "author", "category", "keywords", "comments"),
         }
@@ -174,8 +194,8 @@ def supported_formats():
             "extensions": ("exp",),
             "mimetype": "application/x-exp",
             "category": "embroidery",
-            "reader": ExpReader,
-            "writer": ExpWriter,
+            "reader": _r('ExpReader'),
+            "writer": _r('ExpWriter'),
         }
     )
     # yield (
@@ -185,7 +205,7 @@ def supported_formats():
     #         "extensions": ("cnd",),
     #         "mimetype": "application/x-cnd",
     #         "category": "embroidery",
-    #         "reader": CndReader,
+    #         "reader": _r('CndReader'),
     #     }
     # )
     yield (
@@ -195,8 +215,8 @@ def supported_formats():
             "extensions": ("dst",),
             "mimetype": "application/x-dst",
             "category": "embroidery",
-            "reader": DstReader,
-            "writer": DstWriter,
+            "reader": _r('DstReader'),
+            "writer": _r('DstWriter'),
             "read_options": {
                 "trim_distance": (None, 3.0, 50.0),
                 "trim_at": (2, 3, 4, 5, 6, 7, 8),
@@ -214,8 +234,8 @@ def supported_formats():
             "extensions": ("jef",),
             "mimetype": "application/x-jef",
             "category": "embroidery",
-            "reader": JefReader,
-            "writer": JefWriter,
+            "reader": _r('JefReader'),
+            "writer": _r('JefWriter'),
             "read_options": {
                 "trim_distance": (None, 3.0, 50.0),
                 "trims": (True, False),
@@ -235,8 +255,8 @@ def supported_formats():
             "extensions": ("vp3",),
             "mimetype": "application/x-vp3",
             "category": "embroidery",
-            "reader": Vp3Reader,
-            "writer": Vp3Writer,
+            "reader": _r('Vp3Reader'),
+            "writer": _r('Vp3Writer'),
         }
     )
     yield (
@@ -246,7 +266,7 @@ def supported_formats():
             "extensions": ("svg", "svgz"),
             "mimetype": "image/svg+xml",
             "category": "vector",
-            "writer": SvgWriter,
+            "writer": _r('SvgWriter'),
         }
     )
     yield (
@@ -256,8 +276,8 @@ def supported_formats():
             "extensions": ("csv",),
             "mimetype": "text/csv",
             "category": "debug",
-            "reader": CsvReader,
-            "writer": CsvWriter,
+            "reader": _r('CsvReader'),
+            "writer": _r('CsvWriter'),
             "versions": ("default", "delta", "full"),
         }
     )
@@ -268,8 +288,8 @@ def supported_formats():
             "extensions": ("xxx",),
             "mimetype": "application/x-xxx",
             "category": "embroidery",
-            "reader": XxxReader,
-            "writer": XxxWriter,
+            "reader": _r('XxxReader'),
+            "writer": _r('XxxWriter'),
         }
     )
     yield (
@@ -279,7 +299,7 @@ def supported_formats():
             "extensions": ("sew",),
             "mimetype": "application/x-sew",
             "category": "embroidery",
-            "reader": SewReader,
+            "reader": _r('SewReader'),
         }
     )
     yield (
@@ -289,8 +309,8 @@ def supported_formats():
             "extensions": ("u00", "u01", "u02"),
             "mimetype": "application/x-u01",
             "category": "embroidery",
-            "reader": U01Reader,
-            "writer": U01Writer,
+            "reader": _r('U01Reader'),
+            "writer": _r('U01Writer'),
         }
     )
     yield (
@@ -300,7 +320,7 @@ def supported_formats():
             "extensions": ("shv",),
             "mimetype": "application/x-shv",
             "category": "embroidery",
-            "reader": ShvReader,
+            "reader": _r('ShvReader'),
         }
     )
     yield (
@@ -310,7 +330,7 @@ def supported_formats():
             "extensions": ("10o",),
             "mimetype": "application/x-10o",
             "category": "embroidery",
-            "reader": A10oReader,
+            "reader": _r('A10oReader'),
         }
     )
     yield (
@@ -320,7 +340,7 @@ def supported_formats():
             "extensions": ("100",),
             "mimetype": "application/x-100",
             "category": "embroidery",
-            "reader": A100Reader,
+            "reader": _r('A100Reader'),
         }
     )
     yield (
@@ -330,7 +350,7 @@ def supported_formats():
             "extensions": ("bro",),
             "mimetype": "application/x-Bro",
             "category": "embroidery",
-            "reader": BroReader,
+            "reader": _r('BroReader'),
         }
     )
     yield (
@@ -340,7 +360,7 @@ def supported_formats():
             "extensions": ("dat",),
             "mimetype": "application/x-dat",
             "category": "embroidery",
-            "reader": DatReader,
+            "reader": _r('DatReader'),
         }
     )
     yield (
@@ -350,7 +370,7 @@ def supported_formats():
             "extensions": ("dsb",),
             "mimetype": "application/x-dsb",
             "category": "embroidery",
-            "reader": DsbReader,
+            "reader": _r('DsbReader'),
         }
     )
     yield (
@@ -360,7 +380,7 @@ def supported_formats():
             "extensions": ("dsz",),
             "mimetype": "application/x-dsz",
             "category": "embroidery",
-            "reader": DszReader,
+            "reader": _r('DszReader'),
         }
     )
     yield (
@@ -370,7 +390,7 @@ def supported_formats():
             "extensions": ("emd",),
             "mimetype": "application/x-emd",
             "category": "embroidery",
-            "reader": EmdReader,
+            "reader": _r('EmdReader'),
         }
     )
     yield (
@@ -380,7 +400,7 @@ def supported_formats():
             "extensions": ("e00", "e01", "e02"),
             "mimetype": "application/x-exy",
             "category": "embroidery",
-            "reader": ExyReader,
+            "reader": _r('ExyReader'),
         }
     )
     yield (
@@ -390,7 +410,7 @@ def supported_formats():
             "extensions": ("f00", "f01", "f02"),
             "mimetype": "application/x-fxy",
             "category": "embroidery",
-            "reader": FxyReader,
+            "reader": _r('FxyReader'),
         }
     )
     yield (
@@ -400,7 +420,7 @@ def supported_formats():
             "extensions": ("gt",),
             "mimetype": "application/x-exy",
             "category": "embroidery",
-            "reader": GtReader,
+            "reader": _r('GtReader'),
         }
     )
     yield (
@@ -410,7 +430,7 @@ def supported_formats():
             "extensions": ("inb",),
             "mimetype": "application/x-inb",
             "category": "embroidery",
-            "reader": InbReader,
+            "reader": _r('InbReader'),
         }
     )
     yield (
@@ -420,8 +440,8 @@ def supported_formats():
             "extensions": ("tbf",),
             "mimetype": "application/x-tbf",
             "category": "embroidery",
-            "reader": TbfReader,
-            "writer": TbfWriter,
+            "reader": _r('TbfReader'),
+            "writer": _r('TbfWriter'),
         }
     )
     yield (
@@ -431,7 +451,7 @@ def supported_formats():
             "extensions": ("ksm",),
             "mimetype": "application/x-ksm",
             "category": "embroidery",
-            "reader": KsmReader,
+            "reader": _r('KsmReader'),
         }
     )
     yield (
@@ -441,7 +461,7 @@ def supported_formats():
             "extensions": ("tap",),
             "mimetype": "application/x-tap",
             "category": "embroidery",
-            "reader": TapReader,
+            "reader": _r('TapReader'),
         }
     )
     yield (
@@ -451,7 +471,7 @@ def supported_formats():
             "extensions": ("spx"),
             "mimetype": "application/x-spx",
             "category": "embroidery",
-            "reader": SpxReader,
+            "reader": _r('SpxReader'),
         }
     )
     yield (
@@ -461,7 +481,7 @@ def supported_formats():
             "extensions": ("stx",),
             "mimetype": "application/x-stx",
             "category": "embroidery",
-            "reader": StxReader,
+            "reader": _r('StxReader'),
         }
     )
     yield (
@@ -471,7 +491,7 @@ def supported_formats():
             "extensions": ("phb",),
             "mimetype": "application/x-phb",
             "category": "embroidery",
-            "reader": PhbReader,
+            "reader": _r('PhbReader'),
         }
     )
     yield (
@@ -481,7 +501,7 @@ def supported_formats():
             "extensions": ("phc",),
             "mimetype": "application/x-phc",
             "category": "embroidery",
-            "reader": PhcReader,
+            "reader": _r('PhcReader'),
         }
     )
     yield (
@@ -491,7 +511,7 @@ def supported_formats():
             "extensions": ("new",),
             "mimetype": "application/x-new",
             "category": "embroidery",
-            "reader": NewReader,
+            "reader": _r('NewReader'),
         }
     )
     yield (
@@ -501,7 +521,7 @@ def supported_formats():
             "extensions": ("max",),
             "mimetype": "application/x-max",
             "category": "embroidery",
-            "reader": MaxReader,
+            "reader": _r('MaxReader'),
         }
     )
     yield (
@@ -511,7 +531,7 @@ def supported_formats():
             "extensions": ("mit",),
             "mimetype": "application/x-mit",
             "category": "embroidery",
-            "reader": MitReader,
+            "reader": _r('MitReader'),
         }
     )
     yield (
@@ -521,7 +541,7 @@ def supported_formats():
             "extensions": ("pcd",),
             "mimetype": "application/x-pcd",
             "category": "embroidery",
-            "reader": PcdReader,
+            "reader": _r('PcdReader'),
         }
     )
     yield (
@@ -531,7 +551,7 @@ def supported_formats():
             "extensions": ("pcq",),
             "mimetype": "application/x-pcq",
             "category": "embroidery",
-            "reader": PcqReader,
+            "reader": _r('PcqReader'),
         }
     )
     yield (
@@ -541,7 +561,7 @@ def supported_formats():
             "extensions": ("pcm",),
             "mimetype": "application/x-pcm",
             "category": "embroidery",
-            "reader": PcmReader,
+            "reader": _r('PcmReader'),
         }
     )
     yield (
@@ -551,7 +571,7 @@ def supported_formats():
             "extensions": ("pcs",),
             "mimetype": "application/x-pcs",
             "category": "embroidery",
-            "reader": PcsReader,
+            "reader": _r('PcsReader'),
         }
     )
     yield (
@@ -561,7 +581,7 @@ def supported_formats():
             "extensions": ("jpx",),
             "mimetype": "application/x-jpx",
             "category": "embroidery",
-            "reader": JpxReader,
+            "reader": _r('JpxReader'),
         }
     )
     yield (
@@ -571,7 +591,7 @@ def supported_formats():
             "extensions": ("stc",),
             "mimetype": "application/x-stc",
             "category": "embroidery",
-            "reader": StcReader,
+            "reader": _r('StcReader'),
         }
     )
     yield ({
@@ -580,7 +600,7 @@ def supported_formats():
         "extensions": ("zhs",),
         "mimetype": "application/x-zhs",
         "category": "embroidery",
-        "reader": ZhsReader
+        "reader": _r('ZhsReader')
     })
     yield (
         {
@@ -589,7 +609,7 @@ def supported_formats():
             "extensions": ("z00", "z01", "z02"),
             "mimetype": "application/x-zxy",
             "category": "embroidery",
-            "reader": ZxyReader,
+            "reader": _r('ZxyReader'),
         }
     )
     yield (
@@ -599,8 +619,8 @@ def supported_formats():
             "extensions": ("pmv",),
             "mimetype": "application/x-pmv",
             "category": "stitch",
-            "reader": PmvReader,
-            "writer": PmvWriter,
+            "reader": _r('PmvReader'),
+            "writer": _r('PmvWriter'),
         }
     )
     yield (
@@ -610,7 +630,7 @@ def supported_formats():
             "extensions": ("png",),
             "mimetype": "image/png",
             "category": "image",
-            "writer": PngWriter,
+            "writer": _r('PngWriter'),
             "write_options": {
                 "background": (0x000000, 0xFFFFFF),
                 "linewidth": (1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
@@ -624,7 +644,7 @@ def supported_formats():
             "extensions": ("txt",),
             "mimetype": "text/plain",
             "category": "debug",
-            "writer": TxtWriter,
+            "writer": _r('TxtWriter'),
             "versions": ("default", "embroidermodder"),
         }
     )
@@ -635,8 +655,8 @@ def supported_formats():
             "extensions": ("gcode", "g-code", "ngc", "nc", ".g"),
             "mimetype": "text/plain",
             "category": "embroidery",
-            "reader": GcodeReader,
-            "writer": InkstitchGcodeWriter,
+            "reader": _r('GcodeReader'),
+            "writer": _r('InkstitchGcodeWriter'),
             "write_options": {
                 "flip_x": (True, False),
                 "flip_y": (True, False),
@@ -652,7 +672,7 @@ def supported_formats():
             "extensions": ("hus",),
             "mimetype": "application/x-hus",
             "category": "embroidery",
-            "reader": HusReader,
+            "reader": _r('HusReader'),
         }
     )
     yield(
@@ -662,7 +682,7 @@ def supported_formats():
             "extensions": ("iqp",),
             "mimetype": "application/x-iqp",
             "category": "quilting",
-            "reader": IqpReader,
+            "reader": _r('IqpReader'),
         }
     )
     yield(
@@ -672,8 +692,8 @@ def supported_formats():
             "extensions": ("plt",),
             "mimetype": "text/plain",
             "category": "quilting",
-            "reader": PltReader,
-            "writer": PltWriter,
+            "reader": _r('PltReader'),
+            "writer": _r('PltWriter'),
         }
     )
     yield(
@@ -683,8 +703,8 @@ def supported_formats():
             "extensions": ("qcc",),
             "mimetype": "text/plain",
             "category": "quilting",
-            "reader": QccReader,
-            "writer": QccWriter,
+            "reader": _r('QccReader'),
+            "writer": _r('QccWriter'),
         }
     )
     yield (
@@ -694,8 +714,8 @@ def supported_formats():
             "extensions": ("edr",),
             "mimetype": "application/x-edr",
             "category": "color",
-            "reader": EdrReader,
-            "writer": EdrWriter,
+            "reader": _r('EdrReader'),
+            "writer": _r('EdrWriter'),
         }
     )
     yield (
@@ -705,8 +725,8 @@ def supported_formats():
             "extensions": ("col",),
             "mimetype": "application/x-col",
             "category": "color",
-            "reader": ColReader,
-            "writer": ColWriter,
+            "reader": _r('ColReader'),
+            "writer": _r('ColWriter'),
         }
     )
     yield (
@@ -716,8 +736,8 @@ def supported_formats():
             "extensions": ("inf",),
             "mimetype": "application/x-inf",
             "category": "color",
-            "reader": InfReader,
-            "writer": InfWriter,
+            "reader": _r('InfReader'),
+            "writer": _r('InfWriter'),
         }
     )
     yield (
@@ -727,138 +747,138 @@ def supported_formats():
             "extensions": ("json",),
             "mimetype": "application/json",
             "category": "debug",
-            "reader": JsonReader,
-            "writer": JsonWriter,
+            "reader": _r('JsonReader'),
+            "writer": _r('JsonWriter'),
         }
     )
 
 def read_dst(f, settings=None, pattern=None):
     """Reads fileobject as DST file"""
-    return EmbPattern.read_embroidery(DstReader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('DstReader'), f, settings, pattern)
 
 def read_pec(f, settings=None, pattern=None):
     """Reads fileobject as PEC file"""
-    return EmbPattern.read_embroidery(PecReader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('PecReader'), f, settings, pattern)
 
 def read_pes(f, settings=None, pattern=None):
     """Reads fileobject as PES file"""
-    return EmbPattern.read_embroidery(PesReader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('PesReader'), f, settings, pattern)
 
 def read_exp(f, settings=None, pattern=None):
     """Reads fileobject as EXP file"""
-    return EmbPattern.read_embroidery(ExpReader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('ExpReader'), f, settings, pattern)
 
 def read_vp3(f, settings=None, pattern=None):
     """Reads fileobject as VP3 file"""
-    return EmbPattern.read_embroidery(Vp3Reader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('Vp3Reader'), f, settings, pattern)
 
 def read_jef(f, settings=None, pattern=None):
     """Reads fileobject as JEF file"""
-    return EmbPattern.read_embroidery(JefReader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('JefReader'), f, settings, pattern)
 
 def read_u01(f, settings=None, pattern=None):
     """Reads fileobject as U01 file"""
-    return EmbPattern.read_embroidery(U01Reader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('U01Reader'), f, settings, pattern)
 
 def read_csv(f, settings=None, pattern=None):
     """Reads fileobject as CSV file"""
-    return EmbPattern.read_embroidery(CsvReader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('CsvReader'), f, settings, pattern)
 
 def read_json(f, settings=None, pattern=None):
     """Reads fileobject as JSON file"""
-    return EmbPattern.read_embroidery(JsonReader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('JsonReader'), f, settings, pattern)
 
 def read_gcode(f, settings=None, pattern=None):
     """Reads fileobject as GCode file"""
-    return EmbPattern.read_embroidery(GcodeReader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('GcodeReader'), f, settings, pattern)
 
 def read_xxx(f, settings=None, pattern=None):
     """Reads fileobject as XXX file"""
-    return EmbPattern.read_embroidery(XxxReader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('XxxReader'), f, settings, pattern)
 
 def read_tbf(f, settings=None, pattern=None):
     """Reads fileobject as TBF file"""
-    return EmbPattern.read_embroidery(TbfReader, f, settings, pattern)
+    return EmbPattern.read_embroidery(__getattr__('TbfReader'), f, settings, pattern)
 
 def read_iqp(f, settings=None, pattern=None):
     """Reads fileobject as IQP file"""
-    pattern = EmbPattern.read_embroidery(IqpReader, f, settings, pattern)
+    pattern = EmbPattern.read_embroidery(__getattr__('IqpReader'), f, settings, pattern)
     return pattern
 
 def read_plt(f, settings=None, pattern=None):
     """Reads fileobject as PLT file"""
-    pattern = EmbPattern.read_embroidery(PltReader, f, settings, pattern)
+    pattern = EmbPattern.read_embroidery(__getattr__('PltReader'), f, settings, pattern)
     return pattern
 
 def read_qcc(f, settings=None, pattern=None):
     """Reads fileobject as QCC file"""
-    pattern = EmbPattern.read_embroidery(QccReader, f, settings, pattern)
+    pattern = EmbPattern.read_embroidery(__getattr__('QccReader'), f, settings, pattern)
     return pattern
 
 def write_dst(pattern, stream, settings=None):
     """Writes fileobject as DST file"""
-    EmbPattern.write_embroidery(DstWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('DstWriter'), pattern, stream, settings)
 
 def write_pec(pattern, stream, settings=None):
     """Writes fileobject as PEC file"""
-    EmbPattern.write_embroidery(PecWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('PecWriter'), pattern, stream, settings)
 
 def write_pes(pattern, stream, settings=None):
     """Writes fileobject as PES file"""
-    EmbPattern.write_embroidery(PesWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('PesWriter'), pattern, stream, settings)
 
 def write_exp(pattern, stream, settings=None):
     """Writes fileobject as EXP file"""
-    EmbPattern.write_embroidery(ExpWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('ExpWriter'), pattern, stream, settings)
 
 def write_vp3(pattern, stream, settings=None):
     """Writes fileobject as Vp3 file"""
-    EmbPattern.write_embroidery(Vp3Writer, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('Vp3Writer'), pattern, stream, settings)
 
 def write_jef(pattern, stream, settings=None):
     """Writes fileobject as JEF file"""
-    EmbPattern.write_embroidery(JefWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('JefWriter'), pattern, stream, settings)
 
 def write_u01(pattern, stream, settings=None):
     """Writes fileobject as U01 file"""
-    EmbPattern.write_embroidery(U01Writer, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('U01Writer'), pattern, stream, settings)
 
 def write_csv(pattern, stream, settings=None):
     """Writes fileobject as CSV file"""
-    EmbPattern.write_embroidery(CsvWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('CsvWriter'), pattern, stream, settings)
 
 def write_json(pattern, stream, settings=None):
     """Writes fileobject as JSON file"""
-    EmbPattern.write_embroidery(JsonWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('JsonWriter'), pattern, stream, settings)
 
 def write_txt(pattern, stream, settings=None):
     """Writes fileobject as CSV file"""
-    EmbPattern.write_embroidery(TxtWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('TxtWriter'), pattern, stream, settings)
 
 def write_gcode(pattern, stream, settings=None):
     """Writes fileobject as Gcode file"""
-    EmbPattern.write_embroidery(GcodeWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('GcodeWriter'), pattern, stream, settings)
 
 def write_xxx(pattern, stream, settings=None):
     """Writes fileobject as XXX file"""
-    EmbPattern.write_embroidery(XxxWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('XxxWriter'), pattern, stream, settings)
 
 def write_tbf(pattern, stream, settings=None):
     """Writes fileobject as TBF file"""
-    EmbPattern.write_embroidery(TbfWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('TbfWriter'), pattern, stream, settings)
 
 def write_plt(pattern, stream, settings=None):
     """Writes fileobject as PLT file"""
-    EmbPattern.write_embroidery(PltWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('PltWriter'), pattern, stream, settings)
 
 def write_qcc(pattern, stream, settings=None):
     """Writes fileobject as QCC file"""
-    EmbPattern.write_embroidery(QccWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('QccWriter'), pattern, stream, settings)
 
 def write_svg(pattern, stream, settings=None):
     """Writes fileobject as DST file"""
-    EmbPattern.write_embroidery(SvgWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('SvgWriter'), pattern, stream, settings)
 
 def write_png(pattern, stream, settings=None):
     """Writes fileobject as PNG file"""
-    EmbPattern.write_embroidery(PngWriter, pattern, stream, settings)
+    EmbPattern.write_embroidery(__getattr__('PngWriter'), pattern, stream, settings)

--- a/src/pystitch/pystitch.py
+++ b/src/pystitch/pystitch.py
@@ -1,5 +1,3 @@
-import os.path
-
 from .EmbPattern import EmbPattern
 
 get_extension_by_filename = EmbPattern.get_extension_by_filename

--- a/test/pattern_for_tests.py
+++ b/test/pattern_for_tests.py
@@ -34,27 +34,27 @@ class Turtle:
         self.y += distance * math.sin(self.angle)
 
     def add_gosper(self):
-        a = lambda: self.forward(20)
-        b = lambda: self.forward(20)
-        l = lambda: self.turn(self.turn_amount)
-        r = lambda: self.turn(-self.turn_amount)
-        initial = lambda: None
+        def a(): self.forward(20)
+        def b(): self.forward(20)
+        def ln(): self.turn(self.turn_amount)
+        def r(): self.turn(-self.turn_amount)
+        def initial(): pass
         rules = {
             initial: [a],
-            a: [a, l, b, l, l, b, r, a, r, r, a, a, r, b, l],
-            b: [r, a, l, b, b, l, l, b, l, a, r, r, a, r, b]
+            a: [a, ln, b, ln, ln, b, r, a, r, r, a, a, r, b, ln],
+            b: [r, a, ln, b, b, ln, ln, b, ln, a, r, r, a, r, b]
         }
         evaluate_lsystem(initial, rules, 3)  # 4
 
     def add_serp(self):
-        a = lambda: self.forward(20)
-        b = lambda: self.forward(20)
-        l = lambda: self.turn(self.turn_amount)
-        r = lambda: self.turn(-self.turn_amount)
-        initial = lambda: None
+        def a(): self.forward(20)
+        def b(): self.forward(20)
+        def ln(): self.turn(self.turn_amount)
+        def r(): self.turn(-self.turn_amount)
+        def initial(): pass
         rules = {
             initial: [a],
-            a: [b, l, a, l, b],
+            a: [b, ln, a, ln, b],
             b: [a, r, b, r, a]
         }
         evaluate_lsystem(initial, rules, 3)  # 6

--- a/test/test_color_fileformats.py
+++ b/test/test_color_fileformats.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_convert_csv.py
+++ b/test/test_convert_csv.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_convert_dst.py
+++ b/test/test_convert_dst.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 from pystitch import *
 from test.pattern_for_tests import *

--- a/test/test_convert_exp.py
+++ b/test/test_convert_exp.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_convert_gcode.py
+++ b/test/test_convert_gcode.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_convert_jef.py
+++ b/test/test_convert_jef.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_convert_pec.py
+++ b/test/test_convert_pec.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_convert_pes.py
+++ b/test/test_convert_pes.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 from pystitch import *
 from test.pattern_for_tests import *

--- a/test/test_convert_tbf.py
+++ b/test/test_convert_tbf.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_convert_u01.py
+++ b/test/test_convert_u01.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 from pystitch import *
 from test.pattern_for_tests import *

--- a/test/test_convert_vp3.py
+++ b/test/test_convert_vp3.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_convert_xxx.py
+++ b/test/test_convert_xxx.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_datapreservation.py
+++ b/test/test_datapreservation.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 from test.pattern_for_tests import *
 

--- a/test/test_embpattern.py
+++ b/test/test_embpattern.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_generic.py
+++ b/test/test_generic.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *

--- a/test/test_matrix.py
+++ b/test/test_matrix.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 from pystitch import *
 

--- a/test/test_trims_dst_jef.py
+++ b/test/test_trims_dst_jef.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from pystitch import *

--- a/test/test_writes.py
+++ b/test/test_writes.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import os
 import unittest
 
 from test.pattern_for_tests import *


### PR DESCRIPTION
I know this is a large PR, but this was not achievable with fewer changes. I spent days fixing this. I was using Ink/Stitch for the last 2 years and the main problem I found was that it takes too much time to open embroidery designs, even small ones. Now I have fixed that. I tested opening an embroidery design before my changes—it took 4 minutes and 48 seconds to open a design with around 40,000 stitches. After my changes, it now takes around 2 seconds only. While working on this goal, I found some bugs and errors in Ink/Stitch and Pystitch. I initially tried to fix those, thinking they were caused by my changes. However, when I compared my build with the latest build from inkstitch.com, most errors were already present in the official build. By then, I had fixed around 200 bugs and errors. I know studying such a large PR will take significant time, but the results are well worth it. I hope these efforts will save hundreds of hours for humanity. Now let me be technical:

## Summary

This PR delivers two major improvements: a near-elimination of design load time
(278s → ~2s, 99.3% reduction) and correctness fixes across 15+ embroidery
format readers/writers.

---

## Performance: 278s → ~2s load time

### Root cause
Importing `inkex` pulled in the full Inkscape extension stack — including
`shapely`, `cssselect2`, `cssparser`, `lxml`, and dozens of other heavy modules
— on every single file open. This happened even for simple embroidery import
operations that never need any of that.

### Fix: deferred import fast path (`input_fast.py`, `output_fast.py`)
- Added `lib/extensions/input_fast.py`: a lean SVG-generating importer that
  uses only `lxml` + `pystitch`. Handles the common case (M/L path data,
  no clip/mask/filter) without touching inkex or Shapely.
- Added `lib/extensions/output_fast.py`: same approach for export.
- `inkstitch.py` tries the fast path first and falls back to the full path only
  when needed.
- Added `lib/extensions/params_gui.py`: lazy-loads the params dialog so the
  Inkscape extension process starts instantly.

### Stroke element fast path (`lib/elements/stroke.py`)
- Paths composed entirely of M and L commands now bypass the
  `to_superpath()` → CSP → Shapely pipeline entirely.
- Pure M/L paths are extremely common in embroidery imports.

### General import optimizations
- Replaced wildcard imports (`from x import *`) with explicit imports across
  30+ files.
- Deferred heavy imports (`shapely`, `numpy`, `trimesh`, `wx`) to the call
  site rather than module load time.
- Memoized `get_cache_key()` and other hot paths in `lib/utils/cache.py`.