### PR TITLE
Initial SewWriter implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Pystitch will write:
 * .jef (Janome Embroidery Format)
 * .pec (Brother Embroidery Format)
 * .pes (Brother Embroidery Format)
+* .sew (Janome Embroidery Format)
 * .tbf (Tajima Embroidery Format)
 * .u01 (Barudan Embroidery Format)
 * .vp3 (Pfaff Embroidery Format)

--- a/src/pystitch/SewWriter.py
+++ b/src/pystitch/SewWriter.py
@@ -34,6 +34,8 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None) -> None:
 
     # Write index of each color
     for thread in pattern.threadlist:
+        if not thread.catalog_number:
+            continue
         index = int(thread.catalog_number)
         write_int_16le(f, index)
 
@@ -41,7 +43,7 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None) -> None:
     f.seek(STITCH_COUNT_OFFSET, 0)
     for block in pattern.get_as_colorblocks():
         stitches, color = block
-        # This does not seem to produce expected values
+        # This may produce lower than actual values
         count = len([stitch for stitch in stitches if stitch[2] != COLOR_CHANGE])
         write_int_16le(f, count)
 
@@ -70,4 +72,4 @@ def write(pattern: EmbPattern, f: BinaryIO, settings=None) -> None:
             write_int_array_8(f, [dx, -dy])
 
     # End pattern
-    write_int_array_8(f, [0x80, 0x00])
+    write_int_array_8(f, [0x80, 0x10])

--- a/src/pystitch/SewWriter.py
+++ b/src/pystitch/SewWriter.py
@@ -1,0 +1,73 @@
+from typing import BinaryIO
+
+from pystitch.EmbConstant import (
+    COLOR_CHANGE,
+    COMMAND_MASK,
+    END,
+    JUMP,
+    STITCH,
+    TRIM,
+)
+from pystitch.EmbPattern import EmbPattern
+from pystitch.WriteHelper import write_int_16le, write_int_array_8
+
+HEADER_SIZE = 0x1D78
+STITCH_COUNT_OFFSET = 0x32
+
+
+def write(pattern: EmbPattern, f: BinaryIO, settings=None) -> None:
+    """
+    Write pattern to SEW-formatted binary buffer.
+
+    https://edutechwiki.unige.ch/en/Embroidery_format
+    https://community.kde.org/Projects/Liberty/File_Formats/Janome_Embroidery_Format#SEW_Format
+    """
+    # Write initial null bytes for header
+    f.write(bytes(HEADER_SIZE))
+    f.seek(0)
+
+    # Write color count
+    color_count = len(pattern.threadlist)
+    if color_count > 12:
+        raise ValueError("Cannot store more than 12 colors in SEW format")
+    write_int_16le(f, color_count)
+
+    # Write index of each color
+    for thread in pattern.threadlist:
+        index = int(thread.catalog_number)
+        write_int_16le(f, index)
+
+    # Write stitch count for each color
+    f.seek(STITCH_COUNT_OFFSET, 0)
+    for block in pattern.get_as_colorblocks():
+        stitches, color = block
+        # This does not seem to produce expected values
+        count = len([stitch for stitch in stitches if stitch[2] != COLOR_CHANGE])
+        write_int_16le(f, count)
+
+    # Write stitches
+    f.seek(HEADER_SIZE, 0)
+    xx = yy = 0
+    for stitch in pattern.stitches:
+        x, y, command = stitch
+        command &= COMMAND_MASK
+        dx = int(round(x - xx))
+        dy = int(round(y - yy))
+        xx += dx
+        yy += dy
+        if command == END:
+            break
+        elif command == STITCH:
+            write_int_array_8(f, [dx, -dy])
+        elif command == COLOR_CHANGE:
+            write_int_array_8(f, [0x80, 0x01])
+            write_int_array_8(f, [0x00, 0x00])
+        elif command == TRIM:
+            write_int_array_8(f, [0x80, 0x02])
+            write_int_array_8(f, [0x00, 0x00])
+        elif command == JUMP:
+            write_int_array_8(f, [0x80, 0x02])
+            write_int_array_8(f, [dx, -dy])
+
+    # End pattern
+    write_int_array_8(f, [0x80, 0x00])

--- a/src/pystitch/__init__.py
+++ b/src/pystitch/__init__.py
@@ -69,6 +69,7 @@ import pystitch.PngWriter as PngWriter
 import pystitch.QccReader as QccReader
 import pystitch.QccWriter as QccWriter
 import pystitch.SewReader as SewReader
+import pystitch.SewWriter as SewWriter
 import pystitch.ShvReader as ShvReader
 import pystitch.SpxReader as SpxReader
 import pystitch.StcReader as StcReader
@@ -280,6 +281,7 @@ def supported_formats():
             "mimetype": "application/x-sew",
             "category": "embroidery",
             "reader": SewReader,
+            "writer": SewWriter,
         }
     )
     yield (


### PR DESCRIPTION
This is a draft implementation of `SewWriter`.

- Added `pystitch.SewWriter` module
- Added `writer` to `supported_formats` for `sew` extension

### Testing

Patterns have been tested by:

1. Importing a bitmap into [Janome Customizer 2000](https://www.janome.com/support/technical-support/digitizing-software/discontinued-software/)
2. Exporting pattern as SEW format
3. Importing pattern with `pystitch.SewReader`
4. Exporting pattern with `pystitch.SewWriter` (this PR)
5. Opening exported pattern with original software

It has **_not_** yet been tested on a Janome Memory Craft machine, but likely will be in due time.

### Format

The format is a simplified version of JEF, with similar control sequences but with less metadata (see header from KDE Liberty community project documentation below).

| Offset | Length | Type    | Description                                                                                                               |
| --------- | ---------- | ---------- | --------------------------------------------------------------------------------------------------------- |
| 0          | 2           | Count  | Colour count; maximum of 12 colours                                                                |
| 2          | 12x2     | Table   | Colour index table padded with 0; JEF colour code                                           |
| 0x1A   | 12x2     | Table   | Colour unknown; all entries appear to have the same value: 8 or 0 or 255 |
| 0x32   | 12x2     | Table    | Stitches per colour (minus a few)                                                                         |

The stitch data seems to be correct, matching the original data, with the exception of occasional `\x80\x10` control sequences, which are read by `SewReader` as a normal stitch. As this data is lost, it is not possible to reinsert these sequences when writing.
Currently, the writer does not obtain the correct values for the number of stitches per thread/colour (offset `0x32`), causing part of the design not to be displayed in Customizer 2000 (although displayed correctly in InkStitch). When overwritten manually, the patterns display correctly. Any assistance with this would be greatly appreciated. By splitting the original bytes by control sequence `\x80\x02\x00\x00`, I could replicate the original numbers for one pattern (four colours) but not another (one colour). The original bytes are not available in an `EmbPattern` object either, so it would be ideal to get these values from available methods, e.g. `EmbPattern.get_as_colorblocks`.
The bitmap data described in the resources below is not implemented, but does not appear to be necessary.

### Resources

https://edutechwiki.unige.ch/en/Embroidery_format
https://community.kde.org/Projects/Liberty/File_Formats/Janome_Embroidery_Format#SEW_Format