### PR TITLE
fix(pec): do not use reserved machine function from thread catalog

### DIFF
--- a/src/pystitch/EmbThread.py
+++ b/src/pystitch/EmbThread.py
@@ -54,7 +54,7 @@ def find_nearest_color_index(find_color, values):
     closest_index = None
     current_closest_value = float("inf")
     for current_index, t in enumerate(values):
-        if t is None:
+        if t is None or getattr(t, "reserved", False):
             continue
         dist = color_distance_red_mean(
             red, green, blue, t.get_red(), t.get_green(), t.get_blue()

--- a/src/pystitch/EmbThreadPec.py
+++ b/src/pystitch/EmbThreadPec.py
@@ -65,17 +65,19 @@ def get_thread_set():
         EmbThreadPec(9, 91, 166, "Electric Blue", "59"),
         EmbThreadPec(240, 249, 112, "Lemon Yellow", "60"),
         EmbThreadPec(227, 243, 91, "Fresh Green", "61"),
-        EmbThreadPec(255, 153, 0, "Orange", "62"),
-        EmbThreadPec(255, 240, 141, "Cream Yellow", "63"),
-        EmbThreadPec(255, 200, 200, "Applique", "64"),
+        # Machine functions, not real thread colors
+        EmbThreadPec(255, 200, 100, "Applique Material", "62", reserved=True),
+        EmbThreadPec(255, 200, 200, "Applique Position", "63", reserved=True),
+        EmbThreadPec(255, 200, 200, "Applique", "64", reserved=True),
     ]
 
 
 class EmbThreadPec(EmbThread):
-    def __init__(self, red, green, blue, description, catalog_number):
+    def __init__(self, red, green, blue, description, catalog_number, reserved=False):
         EmbThread.__init__(self)
         self.set_color(red, green, blue)
         self.description = description
         self.catalog_number = catalog_number
         self.brand = "Brother"
         self.chart = "Brother"
+        self.reserved = reserved

--- a/test/test_palette.py
+++ b/test/test_palette.py
@@ -43,7 +43,10 @@ class TestPalettes(unittest.TestCase):
         """If the entries equal the list they should all map."""
         pattern = EmbPattern()
         threadset = get_thread_set()
-        for i in range(0, len(threadset)-2):
+        matchable_count = sum(
+            1 for t in threadset if t is not None and not getattr(t, "reserved", False)
+        )
+        for i in range(0, matchable_count):
             thread = EmbThread()
             thread.set_color(i, i, i)
             pattern += thread
@@ -89,6 +92,31 @@ class TestPalettes(unittest.TestCase):
         palette = build_nonrepeat_palette(threadset,pattern.threadlist)
         self.assertEqual(palette[0], palette[3], "Red and Red")
         self.assertEqual(palette[1], palette[2], "Blue and Blue")
+
+    def test_reserved_indices_excluded_from_matching(self):
+        threadset = get_thread_set()
+        for i in (62, 63, 64):
+            self.assertTrue(threadset[i].reserved)
+
+        # Two colliding "Deep Gold" threads used to fall through to the
+        # reserved index 62 slot (inkstitch#1105).
+        pattern = EmbPattern()
+        gold1 = EmbThread()
+        gold1.set_color(0xE8, 0xA9, 0x00)
+        gold2 = EmbThread()
+        gold2.set_color(0xE8, 0xA9, 0x00)
+        pattern.threadlist = [gold1, gold2]
+        palette = build_unique_palette(get_thread_set(), pattern.threadlist)
+        self.assertNotIn(62, palette)
+        self.assertNotIn(63, palette)
+        self.assertNotIn(64, palette)
+
+        # An RGB value that lands on reserved must resolve to a real color
+        # instead.
+        exact = EmbThread()
+        exact.set_color(255, 200, 200)
+        index = exact.find_nearest_color_index(get_thread_set())
+        self.assertNotIn(index, (62, 63, 64))
 
     def test_palette(self):
         """Similar colors map to the same index"""


### PR DESCRIPTION
Fixes part of inkstitch/inkstitch#2668 which references several problems. This PR addresses inkstitch/inkstitch#568 and inkstitch/inkstitch#1105. Due to the color choices in those users' designs, the closest color in the Brother palette were these codes which are meant as applique functions, not an actual color stop.

Besides the [usual reference](https://edutechwiki.unige.ch/en/Embroidery_format_PEC#Writing_PEC), I manually verified these on my SE700 (and cross-checked my physical manual that the function name is correct):
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e61f4167-d505-4535-bb18-231a1d929dd8" />

Meanwhile, every single RGB value in EmbThreadPec.py does not match those in the edutechwiki reference. I used AI to find the 6 biggest differences (pystitch on the left, edutechwiki on the right):
<img width="300" alt="Screenshot 2026-07-10 at 7 12 10 PM" src="https://github.com/user-attachments/assets/8cc4597a-57e0-4da4-a321-0bc897b3fa56" />
I then tested these pec codes on my SE700 and pystitch (the left) was the clear winner. Not sure why edutechwiki has these wrong, as I believe I read that this library and that resource share the same author.